### PR TITLE
chore(qa): Trigger Metadata ingestion tests for any PRs

### DIFF
--- a/.github/auto-label.json
+++ b/.github/auto-label.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "test-apis-metadataIngestionTest": ["**"]
+  }
+}

--- a/.github/workflows/auto-label.yaml
+++ b/.github/workflows/auto-label.yaml
@@ -1,0 +1,14 @@
+name: Auto Label
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  auto-label:
+    name: Auto Label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: banyan/auto-label@1.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,6 @@
+#!groovy
+
+@Library('cdis-jenkins-lib@master') _
+
+testPipeline { 
+}


### PR DESCRIPTION
Enabling CI checks against this repo -- Running metadata ingestion tests only.