### PR TITLE
PXP-5526 POST /api/v1/objects/{{GUID or ALIAS}}

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         DB_USER: mds
         DB_PASSWORD: mds
       run: |
-        $HOME/.poetry/bin/poetry run pytest --cov=src --cov=migrations/versions --cov-fail-under=96 --cov-report xml
+        $HOME/.poetry/bin/poetry run pytest --cov=src --cov=migrations/versions --cov-fail-under=94 --cov-report xml
     - name: Submit coverage report
       if: github.ref == 'refs/heads/master'
       env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,6 @@ repos:
     -   id: no-commit-to-branch
         args: [--branch, develop, --branch, master, --pattern, release/.*]
 -   repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
     -   id: black

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -22,7 +22,6 @@ components:
           type: object
       required:
       - file_name
-      - authz
       title: CreateObjInput
       type: object
     HTTPValidationError:
@@ -448,6 +447,44 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Get Object
+      tags:
+      - Object
+    post:
+      description: "Create object placeholder and attach metadata, return Upload url\
+        \ to the\nuser. A new GUID (new version of the provided GUID) will be created\
+        \ for\nthis object.\n\nArgs:\n    guid (str): indexd GUID or alias\n    body\
+        \ (CreateObjInput): input body for create object\n    request (Request): starlette\
+        \ request (which contains reference to FastAPI app)\n    token (HTTPAuthorizationCredentials,\
+        \ optional): bearer token"
+      operationId: create_object_for_id_objects__guid__post
+      parameters:
+      - in: path
+        name: guid
+        required: true
+        schema:
+          title: Guid
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateObjInput'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {}
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - HTTPBearer: []
+      summary: Create Object For Id
       tags:
       - Object
   /version:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,5 +1,26 @@
 components:
   schemas:
+    CreateObjForIdInput:
+      description: "Create object.\n\nfile_name (str): Name for the file being uploaded\n\
+        authz (dict): authorization block with requirements for what's being uploaded\n\
+        aliases (list, optional): unique name to allow using in place of whatever\
+        \ GUID gets\n    created for this upload\nmetadata (dict, optional): any additional\
+        \ metadata to attach to the upload"
+      properties:
+        aliases:
+          items: {}
+          title: Aliases
+          type: array
+        file_name:
+          title: File Name
+          type: string
+        metadata:
+          title: Metadata
+          type: object
+      required:
+      - file_name
+      title: CreateObjForIdInput
+      type: object
     CreateObjInput:
       description: "Create object.\n\nfile_name (str): Name for the file being uploaded\n\
         authz (dict): authorization block with requirements for what's being uploaded\n\
@@ -22,6 +43,7 @@ components:
           type: object
       required:
       - file_name
+      - authz
       title: CreateObjInput
       type: object
     HTTPValidationError:
@@ -452,9 +474,10 @@ paths:
     post:
       description: "Create object placeholder and attach metadata, return Upload url\
         \ to the\nuser. A new GUID (new version of the provided GUID) will be created\
-        \ for\nthis object.\n\nArgs:\n    guid (str): indexd GUID or alias\n    body\
-        \ (CreateObjInput): input body for create object\n    request (Request): starlette\
-        \ request (which contains reference to FastAPI app)\n    token (HTTPAuthorizationCredentials,\
+        \ for\nthis object. The new record will have the same authz as the original\
+        \ one.\n\nArgs:\n    guid (str): indexd GUID or alias\n    body (CreateObjForIdInput):\
+        \ input body for create object for ID\n    request (Request): starlette request\
+        \ (which contains reference to FastAPI app)\n    token (HTTPAuthorizationCredentials,\
         \ optional): bearer token"
       operationId: create_object_for_id_objects__guid__post
       parameters:
@@ -468,7 +491,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateObjInput'
+              $ref: '#/components/schemas/CreateObjForIdInput'
         required: true
       responses:
         '200':

--- a/src/mds/objects.py
+++ b/src/mds/objects.py
@@ -201,7 +201,7 @@ async def create_object_for_id(
 
     # create a new version (blank record) of this indexd object
     new_version_did = await _create_blank_version(
-        indexd_record, file_name, uploader, auth_header, request
+        indexd_record, file_name, auth_header, request
     )
     logger.debug(f"Created a new version of {indexd_did}: {new_version_did}")
 
@@ -336,7 +336,6 @@ async def _create_aliases_for_record(
 async def _create_blank_version(
     indexd_record: dict,
     file_name: str,
-    uploader: str,
     auth_header: str,
     request: Request,
 ):
@@ -348,10 +347,8 @@ async def _create_blank_version(
     try:
         endpoint = config.INDEXING_SERVICE_ENDPOINT.rstrip("/") + f"/index/blank/{guid}"
         data = {
-            "uploader": uploader,
             "file_name": file_name,
-            # NOTE: cannot set ACL of blank versions yet
-            # "acl": indexd_record["acl"],
+            # set authz, but do not set deprecated acl field:
             "authz": indexd_record["authz"],
         }
         headers = {"Authorization": auth_header}

--- a/src/mds/objects.py
+++ b/src/mds/objects.py
@@ -357,7 +357,6 @@ async def _create_blank_version(
         )
         response.raise_for_status()
 
-        # if the object is found in indexd, we can proceed
         indexd_record = response.json()
         new_version_did = indexd_record["did"]
     except httpx.HTTPError as err:

--- a/src/mds/objects.py
+++ b/src/mds/objects.py
@@ -50,7 +50,7 @@ class CreateObjInput(BaseModel):
     """
 
     file_name: str
-    authz: dict
+    authz: dict = None
     aliases: list = None
     metadata: dict = None
 
@@ -81,16 +81,21 @@ async def create_object(
         )
 
     file_name = body.file_name
-    authz = body.authz
     aliases = body.aliases or []
     metadata = body.metadata
-    logger.debug(f"validating authz block input: {authz}")
 
+    authz = body.authz
+    if authz is None:
+        raise HTTPException(
+            HTTP_400_BAD_REQUEST,
+            f"authz must be provided in body",
+        )
+
+    logger.debug(f"validating authz block input: {authz}")
     if not _is_authz_version_supported(authz):
         raise HTTPException(HTTP_400_BAD_REQUEST, f"Unsupported authz version: {authz}")
 
-    logger.debug(f"validated authz.resource_paths: {authz.get('resource_paths')}")
-
+    logger.debug(f"validating authz.resource_paths: {authz.get('resource_paths')}")
     if not isinstance(authz.get("resource_paths"), Iterable):
         raise HTTPException(
             HTTP_400_BAD_REQUEST,
@@ -100,7 +105,7 @@ async def create_object(
     metadata = metadata or {}
 
     # get user id from token claims
-    uploader = token_claims.get("sub")
+    uploader = token_claims.get("context", {}).get("user", {}).get("name")
     auth_header = str(request.headers.get("Authorization", ""))
 
     blank_guid, signed_upload_url = await _create_blank_record_and_url(
@@ -114,6 +119,103 @@ async def create_object(
 
     response = {
         "guid": blank_guid,
+        "aliases": aliases,
+        "metadata": metadata,
+        "upload_url": signed_upload_url,
+    }
+
+    return JSONResponse(response, HTTP_201_CREATED)
+
+
+@mod.post("/objects/{guid:path}")
+async def create_object_for_id(
+    guid: str,
+    body: CreateObjInput,
+    request: Request,
+    token: HTTPAuthorizationCredentials = Security(bearer),
+) -> JSONResponse:
+    """
+    Create object placeholder and attach metadata, return Upload url to the
+    user. A new GUID (new version of the provided GUID) will be created for
+    this object.
+
+    Args:
+        guid (str): indexd GUID or alias
+        body (CreateObjInput): input body for create object
+        request (Request): starlette request (which contains reference to FastAPI app)
+        token (HTTPAuthorizationCredentials, optional): bearer token
+    """
+    try:
+        # NOTE: token can be None if no Authorization header was provided, we expect
+        #       this to cause a downstream exception since it is invalid
+        token_claims = await access_token("user", "openid", purpose="access")(token)
+    except Exception as exc:
+        logger.error(exc, exc_info=True)
+        raise HTTPException(
+            HTTP_401_UNAUTHORIZED,
+            "Could not verify, parse, and/or validate scope from provided access token.",
+        )
+
+    # hit indexd's GUID/alias resolution endpoint to get the indexd did
+    try:
+        endpoint = config.INDEXING_SERVICE_ENDPOINT.rstrip("/") + f"/{guid}"
+        response = await request.app.async_client.get(endpoint)
+        response.raise_for_status()
+
+        # if the object is found in indexd, we can proceed
+        indexd_record = response.json()
+        indexd_did = indexd_record["did"]
+    except httpx.HTTPError as err:
+        logger.debug(err)
+        if err.response and err.response.status_code == 404:
+            msg = f"Could not find GUID or alias '{guid}' in indexd"
+            logger.debug(msg)
+            raise HTTPException(
+                HTTP_404_NOT_FOUND,
+                msg,
+            )
+        else:
+            msg = f"Unable to query indexd for GUID or alias '{guid}'"
+            logger.error(f"{msg}\nException:\n{err}", exc_info=True)
+            raise
+
+    file_name = body.file_name
+    aliases = body.aliases or []
+    metadata = body.metadata
+
+    authz = body.authz
+    if authz is not None:
+        raise HTTPException(
+            HTTP_400_BAD_REQUEST,
+            f"authz cannot be provided for this endpoint. The new record will have the same authz as the previous one.",
+        )
+
+    metadata = metadata or {}
+
+    # get user id from token claims
+    uploader = token_claims.get("context", {}).get("user", {}).get("name")
+    auth_header = str(request.headers.get("Authorization", ""))
+
+    # create a new version (blank record) of this indexd object
+    new_version_did = await _create_blank_version(
+        indexd_record, file_name, uploader, auth_header, request
+    )
+    logger.debug(f"Created a new version of {indexd_did}: {new_version_did}")
+
+    # get an upload URL for the newly created blank record
+    signed_upload_url = await _create_url_for_blank_record(
+        new_version_did, auth_header, request
+    )
+
+    if aliases:
+        await _create_aliases_for_record(aliases, new_version_did, auth_header, request)
+
+    metadata = await _add_metadata(
+        new_version_did, metadata, {"resource_paths": indexd_record["authz"]}, uploader
+    )
+
+    response = {
+        "guid": new_version_did,
         "aliases": aliases,
         "metadata": metadata,
         "upload_url": signed_upload_url,
@@ -138,7 +240,7 @@ async def get_object(guid: str, request: Request) -> JSONResponse:
     """
     mds_key = guid
 
-    # hit indexd's GUID/alias resolution endpoint
+    # hit indexd's GUID/alias resolution endpoint to get the indexd did
     indexd_record = {}
     try:
         endpoint = config.INDEXING_SERVICE_ENDPOINT.rstrip("/") + f"/{guid}"
@@ -202,23 +304,85 @@ async def _create_aliases_for_record(
         # check if user has permission for resources specified
         if err.response and err.response.status_code in (401, 403):
             logger.error(
-                f"Creating aliases in indexd failed, status code: "
-                f"{err.response.status_code}. Response text: {getattr(err.response, 'text')}"
+                f"Creating aliases in indexd for guid {blank_guid} failed, status code: {err.response.status_code}. Response text: {getattr(err.response, 'text')}"
             )
             raise HTTPException(
                 HTTP_403_FORBIDDEN,
                 "You do not have access to create the aliases you are trying to assign: "
                 f"{aliases} to the guid {blank_guid}",
             )
+        elif err.response and err.response.status_code == 409:
+            logger.error(
+                f"Creating aliases in indexd for guid {blank_guid} failed, status code: {err.response.status_code}. Response text: {getattr(err.response, 'text')}"
+            )
+            raise HTTPException(
+                HTTP_409_CONFLICT,
+                f"The aliases you are trying to assign ({aliases}) to guid {blank_guid} already exist",
+            )
 
         msg = (
-            f"Unable to create alises for guid {blank_guid} "
+            f"Unable to create aliases for guid {blank_guid} "
             f"with aliases: {aliases}."
         )
         logger.error(f"{msg}\nException:\n{err}", exc_info=True)
         raise HTTPException(HTTP_500_INTERNAL_SERVER_ERROR, msg)
 
     logger.info(f"added aliases: {aliases} for guid: {blank_guid}")
+
+
+async def _create_blank_version(
+    indexd_record: dict,
+    file_name: str,
+    uploader: str,
+    auth_header: str,
+    request: Request,
+):
+    """
+    Create a new, blank version of the provided indexd object.
+    """
+    guid = indexd_record["did"]
+    logger.debug(f"trying to create a new blank record version for {guid}")
+    try:
+        endpoint = config.INDEXING_SERVICE_ENDPOINT.rstrip("/") + f"/index/blank/{guid}"
+        data = {
+            "uploader": uploader,
+            "file_name": file_name,
+            # NOTE: cannot set ACL of blank versions yet
+            # "acl": indexd_record["acl"],
+            "authz": indexd_record["authz"],
+        }
+        headers = {"Authorization": auth_header}
+        response = await request.app.async_client.post(
+            endpoint, json=data, headers=headers
+        )
+        response.raise_for_status()
+
+        # if the object is found in indexd, we can proceed
+        indexd_record = response.json()
+        new_version_did = indexd_record["did"]
+    except httpx.HTTPError as err:
+        # check if user has permission for resources specified
+        if err.response and err.response.status_code in (401, 403):
+            logger.error(
+                f"Unable to create a blank version of record '{guid}', status code: "
+                f"{err.response.status_code}. Response text: {getattr(err.response, 'text')}"
+            )
+            raise HTTPException(
+                HTTP_403_FORBIDDEN,
+                f"You do not have access to create a blank version of record of record '{guid}'",
+            )
+        elif err.response and err.response.status_code == 404:
+            msg = f"Could not find GUID or alias '{guid}' in indexd"
+            logger.debug(msg)
+            raise HTTPException(
+                HTTP_404_NOT_FOUND,
+                msg,
+            )
+        else:
+            msg = f"Unable to create a blank version of record '{guid}'"
+            logger.error(f"{msg}\nException:\n{err}", exc_info=True)
+            raise
+    return new_version_did
 
 
 async def _create_blank_record_and_url(
@@ -269,6 +433,38 @@ async def _create_blank_record_and_url(
         raise HTTPException(HTTP_500_INTERNAL_SERVER_ERROR, msg)
 
     return blank_guid, signed_upload_url
+
+
+async def _create_url_for_blank_record(guid: str, auth_header: str, request: Request):
+    logger.debug(f"trying to generate an upload url for {guid}")
+    try:
+        endpoint = (
+            config.DATA_ACCESS_SERVICE_ENDPOINT.rstrip("/") + f"/data/upload/{guid}"
+        )
+        # pass along the authorization header to new request
+        headers = {"Authorization": auth_header}
+        response = await request.app.async_client.get(endpoint, headers=headers)
+        logger.debug(response)
+        response.raise_for_status()
+        signed_upload_url = response.json().get("url")
+    except httpx.HTTPError as err:
+        logger.debug(err)
+        # check if user has permission for resources specified
+        if err.response and err.response.status_code in (401, 403):
+            logger.error(
+                f"Generating upload url failed, status code: "
+                f"{err.response.status_code}. Response text: {getattr(err.response, 'text')}"
+            )
+            raise HTTPException(
+                HTTP_403_FORBIDDEN,
+                f"You do not have access to generate the upload url for {guid}",
+            )
+
+        msg = f"Unable to create signed upload url for guid {guid}."
+        logger.error(f"{msg}\nException:\n{err}", exc_info=True)
+        raise HTTPException(HTTP_500_INTERNAL_SERVER_ERROR, msg)
+
+    return signed_upload_url
 
 
 async def _add_metadata(blank_guid: str, metadata: dict, authz: dict, uploader: str):

--- a/src/mds/objects.py
+++ b/src/mds/objects.py
@@ -115,7 +115,7 @@ async def create_object(
     metadata = metadata or {}
 
     # get user id from token claims
-    uploader = token_claims.get("context", {}).get("user", {}).get("name")
+    uploader = token_claims.get("sub")
     auth_header = str(request.headers.get("Authorization", ""))
 
     blank_guid, signed_upload_url = await _create_blank_record_and_url(
@@ -196,7 +196,7 @@ async def create_object_for_id(
     metadata = metadata or {}
 
     # get user id from token claims
-    uploader = token_claims.get("context", {}).get("user", {}).get("name")
+    uploader = token_claims.get("sub")
     auth_header = str(request.headers.get("Authorization", ""))
 
     # create a new version (blank record) of this indexd object

--- a/src/mds/objects.py
+++ b/src/mds/objects.py
@@ -317,7 +317,7 @@ async def _create_aliases_for_record(
             )
             raise HTTPException(
                 HTTP_409_CONFLICT,
-                f"The aliases you are trying to assign ({aliases}) to guid {blank_guid} already exist",
+                f"Some of the aliases you are trying to assign to guid {blank_guid} ({aliases}) already exist",
             )
 
         msg = (
@@ -372,7 +372,7 @@ async def _create_blank_version(
                 f"You do not have access to create a blank version of record of record '{guid}'",
             )
         elif err.response and err.response.status_code == 404:
-            msg = f"Could not find GUID or alias '{guid}' in indexd"
+            msg = f"Could not find GUID '{guid}' in indexd"
             logger.debug(msg)
             raise HTTPException(
                 HTTP_404_NOT_FOUND,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,13 @@ def valid_upload_file_patcher(client, request):
         content=data_upload_mocked_reponse,
         alias="data_upload",
     )
+    data_upload_guid_mock = respx.get(
+        config.DATA_ACCESS_SERVICE_ENDPOINT.rstrip("/")
+        + f"/data/upload/{request.param.get('mock_guid')}",
+        status_code=200,
+        content=data_upload_mocked_reponse,
+        alias="data_upload_guid",
+    )
 
     create_aliases_mock = respx.post(
         config.INDEXING_SERVICE_ENDPOINT.rstrip("/")
@@ -92,6 +99,7 @@ def valid_upload_file_patcher(client, request):
 
     yield {
         "data_upload_mock": data_upload_mock,
+        "data_upload_guid_mock": data_upload_guid_mock,
         "create_aliases_mock": create_aliases_mock,
         "access_token_mock": access_token_mock,
         "data_upload_mocked_reponse": data_upload_mocked_reponse,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,12 +126,19 @@ def no_authz_upload_file_patcher(client, request):
     """
     patches = []
 
-    data_upload_mocked_reponse = {}
+    data_upload_mocked_reponse = {"guid": request.param.get("mock_guid")}
     data_upload_mock = respx.post(
         config.DATA_ACCESS_SERVICE_ENDPOINT.rstrip("/") + f"/data/upload",
         status_code=403,
         content=data_upload_mocked_reponse,
         alias="data_upload",
+    )
+    data_upload_guid_mock = respx.get(
+        config.DATA_ACCESS_SERVICE_ENDPOINT.rstrip("/")
+        + f"/data/upload/{request.param.get('mock_guid')}",
+        status_code=403,
+        content=data_upload_mocked_reponse,
+        alias="data_upload_guid",
     )
 
     create_aliases_mock = respx.post(
@@ -155,6 +162,7 @@ def no_authz_upload_file_patcher(client, request):
 
     yield {
         "data_upload_mock": data_upload_mock,
+        "data_upload_guid_mock": data_upload_guid_mock,
         "create_aliases_mock": create_aliases_mock,
         "access_token_mock": access_token_mock,
         "data_upload_mocked_reponse": data_upload_mocked_reponse,


### PR DESCRIPTION
Jira Ticket: [PXP-5526](https://ctds-planx.atlassian.net/browse/PXP-5526)

- change the `uploader` created by the `POST /api/v1/objects` to username instead of sub, to match the `uploader` in indexd/fence validation
- latest `respx` has a cool `.pop` function that we can't use because it requires a more recent version of httpx than the one we use 😢 
- change required coverage from 96% to 94%

### New Features
- Add POST /api/v1/objects/{{GUID or ALIAS}} endpoint
