### PR TITLE
PXP-5531 GET /objects/{{GUID or ALIAS}}/download

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -515,12 +515,11 @@ paths:
         \ download\nurl for the given GUID or alias. Returns the generated signed\
         \ download url\nto the user.\n\nArgs:\n    guid (str): indexd GUID or alias\n\
         \    request (Request): starlette request (which contains reference to FastAPI\
-        \ app)\n\nReturns:\n    200: { \"guid\": GUID or alias, \"download_url\":\
-        \ signed download url }\n    404: if the data access service can not find\
-        \ GUID/alias in indexd\n    403: if the data access service returns a 401\
-        \ or a 403\n    500: if there is an error making the request to the data access\
-        \ service\n    or the data access service returns any other 400-range or 500-range\n\
-        \    error"
+        \ app)\n\nReturns:\n    200: { \"url\": signed download url }\n    404: if\
+        \ the data access service can not find GUID/alias in indexd\n    403: if the\
+        \ data access service returns a 401 or a 403\n    500: if there is an error\
+        \ making the request to the data access service\n    or the data access service\
+        \ returns any other 400-range or 500-range\n    error"
       operationId: get_object_signed_download_url_objects__guid__download_get
       parameters:
       - in: path

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2,7 +2,6 @@ components:
   schemas:
     CreateObjForIdInput:
       description: "Create object.\n\nfile_name (str): Name for the file being uploaded\n\
-        authz (dict): authorization block with requirements for what's being uploaded\n\
         aliases (list, optional): unique name to allow using in place of whatever\
         \ GUID gets\n    created for this upload\nmetadata (dict, optional): any additional\
         \ metadata to attach to the upload"
@@ -74,18 +73,6 @@ components:
       - type
       title: ValidationError
       type: object
-    DownloadResponse:
-      description: "Signed download url response"
-      properties:
-        guid:
-          title: GUID
-          type: string
-        download_url:
-          title: Signed Download URL
-          type: string
-      title: DownloadResponse
-      type: object
-
   securitySchemes:
     HTTPBasic:
       scheme: basic
@@ -524,8 +511,17 @@ paths:
       - Object
   /objects/{guid}/download:
     get:
-      description: "Proxy to data access service to return a signed download url for the given GUID/alias."
-      operationId: get_object_signed_download_url_objects__guid__get
+      description: "Send a GET request to the data access service to generate a signed\
+        \ download\nurl for the given GUID or alias. Returns the generated signed\
+        \ download url\nto the user.\n\nArgs:\n    guid (str): indexd GUID or alias\n\
+        \    request (Request): starlette request (which contains reference to FastAPI\
+        \ app)\n\nReturns:\n    200: { \"guid\": GUID or alias, \"download_url\":\
+        \ signed download url }\n    404: if the data access service can not find\
+        \ GUID/alias in indexd\n    403: if the data access service returns a 401\
+        \ or a 403\n    500: if there is an error making the request to the data access\
+        \ service\n    or the data access service returns any other 400-range or 500-range\n\
+        \    error"
+      operationId: get_object_signed_download_url_objects__guid__download_get
       parameters:
       - in: path
         name: guid
@@ -537,10 +533,15 @@ paths:
         '200':
           content:
             application/json:
-              schema:
-                $ref: '#/components/schemas/DownloadResponse'
+              schema: {}
           description: Successful Response
-      summary: Get Signed Download URL
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Object Signed Download Url
       tags:
       - Object
   /version:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -74,6 +74,18 @@ components:
       - type
       title: ValidationError
       type: object
+    DownloadResponse:
+      description: "Signed download url response"
+      properties:
+        guid:
+          title: GUID
+          type: string
+        download_url:
+          title: Signed Download URL
+          type: string
+      title: DownloadResponse
+      type: object
+
   securitySchemes:
     HTTPBasic:
       scheme: basic
@@ -508,6 +520,27 @@ paths:
       security:
       - HTTPBearer: []
       summary: Create Object For Id
+      tags:
+      - Object
+  /objects/{guid}/download:
+    get:
+      description: "Proxy to data access service to return a signed download url for the given GUID/alias."
+      operationId: get_object_signed_download_url_objects__guid__get
+      parameters:
+      - in: path
+        name: guid
+        required: true
+        schema:
+          title: Guid
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DownloadResponse'
+          description: Successful Response
+      summary: Get Signed Download URL
       tags:
       - Object
   /version:

--- a/src/mds/objects.py
+++ b/src/mds/objects.py
@@ -232,7 +232,9 @@ async def get_object_signed_download_url(
     request: Request,
 ) -> JSONResponse:
     """
-    XXX add comments
+    Send a GET request to the data access service to generate a signed download
+    url for the given GUID or alias. Returns the generated signed download url
+    to the user.
 
     Args:
         guid (str): indexd GUID or alias
@@ -244,7 +246,7 @@ async def get_object_signed_download_url(
         )
         auth_header = str(request.headers.get("Authorization", ""))
         logger.debug(
-            f"Attempting to GET signed download url from fence for guid {guid}"
+            f"Attempting to GET signed download url from data access service for GUID or alias '{guid}'"
         )
         response = await request.app.async_client.get(
             endpoint, headers={"Authorization": auth_header}
@@ -252,22 +254,22 @@ async def get_object_signed_download_url(
         response.raise_for_status()
         signed_download_url = response.json().get("url")
     except httpx.HTTPError as err:
-        msg = f"Unable to get signed download url from fence for guid {guid}"
+        msg = f"Unable to get signed download url from data access service for GUID or alias '{guid}'"
         logger.error(f"{msg}\nException:\n{err}", exc_info=True)
         if err.response:
             logger.error(
-                f"fence response status code: {err.response.status_code}\n"
-                f"fence response text:\n{getattr(err.response, 'text')}"
+                f"data access service response status code: {err.response.status_code}\n"
+                f"data access service response text:\n{getattr(err.response, 'text')}"
             )
             if err.response.status_code in (401, 403):
                 raise HTTPException(
                     HTTP_403_FORBIDDEN,
-                    f"{msg}. You do not have access to generate the download url for guid {guid}.",
+                    f"{msg}. You do not have access to generate the download url for GUID or alias '{guid}'.",
                 )
             elif err.response.status_code == 404:
                 raise HTTPException(
                     HTTP_404_NOT_FOUND,
-                    f"{msg}. Record with guid {guid} was not found in indexd.",
+                    f"{msg}. Record with GUID or alias '{guid}' was not found in indexd.",
                 )
         raise HTTPException(HTTP_500_INTERNAL_SERVER_ERROR, msg)
 

--- a/src/mds/objects.py
+++ b/src/mds/objects.py
@@ -239,6 +239,14 @@ async def get_object_signed_download_url(
     Args:
         guid (str): indexd GUID or alias
         request (Request): starlette request (which contains reference to FastAPI app)
+
+    Returns:
+        200: { "guid": GUID or alias, "download_url": signed download url }
+        404: if the data access service can not find GUID/alias in indexd
+        403: if the data access service returns a 401 or a 403
+        500: if there is an error making the request to the data access service
+        or the data access service returns any other 400-range or 500-range
+        error
     """
     try:
         endpoint = (

--- a/src/mds/objects.py
+++ b/src/mds/objects.py
@@ -281,7 +281,7 @@ async def get_object_signed_download_url(
                 )
         raise HTTPException(HTTP_500_INTERNAL_SERVER_ERROR, msg)
 
-    response = {"guid": guid, "download_url": signed_download_url}
+    response = {"url": signed_download_url}
     return JSONResponse(response, HTTP_200_OK)
 
 

--- a/src/mds/objects.py
+++ b/src/mds/objects.py
@@ -241,7 +241,7 @@ async def get_object_signed_download_url(
         request (Request): starlette request (which contains reference to FastAPI app)
 
     Returns:
-        200: { "guid": GUID or alias, "download_url": signed download url }
+        200: { "url": signed download url }
         404: if the data access service can not find GUID/alias in indexd
         403: if the data access service returns a 401 or a 403
         500: if there is an error making the request to the data access service

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,30 @@ def client():
 
 
 @pytest.fixture(
+    params=[
+        "dg.TEST/87fced8d-b9c8-44b5-946e-c465c8f8f3d6",
+        "87fced8d-b9c8-44b5-946e-c465c8f8f3d6",
+    ]
+)
+def guid_mock(request):
+    yield request.param
+
+
+@pytest.fixture()
+def signed_url_mock():
+    yield "https://mock-signed-url"
+
+
+@pytest.fixture()
+def download_endpoints(guid_mock):
+    yield {
+        "guid_mock": guid_mock,
+        "mds": f"/objects/{guid_mock}/download",
+        "fence": f"{config.DATA_ACCESS_SERVICE_ENDPOINT}/data/download/{guid_mock}",
+    }
+
+
+@pytest.fixture(
     scope="function",
     params=[
         # guid w/ prefix

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,20 +49,30 @@ def client():
     ]
 )
 def guid_mock(request):
+    """
+    Yields guid mock.
+    """
     yield request.param
 
 
 @pytest.fixture()
 def signed_url_mock():
+    """
+    Yields signed url mock.
+    """
     yield "https://mock-signed-url"
 
 
 @pytest.fixture()
 def download_endpoints(guid_mock):
+    """
+    Yields dictionary with guid_mock and download endpoints for mds and data
+    access service.
+    """
     yield {
         "guid_mock": guid_mock,
         "mds": f"/objects/{guid_mock}/download",
-        "fence": f"{config.DATA_ACCESS_SERVICE_ENDPOINT}/data/download/{guid_mock}",
+        "data_access": f"{config.DATA_ACCESS_SERVICE_ENDPOINT}/data/download/{guid_mock}",
     }
 
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -812,10 +812,8 @@ def test_get_object_signed_download_url_for_data_access_200(
     assert data_access_signed_download_get_request_mock.called
     assert resp.status_code == 200, resp.text
     resp_json = resp.json()
-    assert "guid" in resp_json
-    assert "download_url" in resp_json
-    assert resp_json["guid"] == download_endpoints["guid_mock"]
-    assert resp_json["download_url"] == signed_url_mock
+    assert "url" in resp_json
+    assert resp_json["url"] == signed_url_mock
 
 
 @respx.mock

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -792,3 +792,45 @@ def test_get_object_not_in_indexd(client):
         assert resp.json() == {"record": {}, "metadata": mds_data}
     finally:
         client.delete("/metadata/" + guid_or_alias)
+
+
+@respx.mock
+def test_get_object_signed_download_url(client):
+    """
+    XXX
+    """
+    guid = "1234"
+    signed_download_url = "https://cats.com/download/paws"
+    #  indexd_did = "test_did"
+
+    #  mock the request to indexd: GUID or alias found in indexd XXX
+    fence_url = f"{config.DATA_ACCESS_SERVICE_ENDPOINT}/data/download/{guid}"
+    fence_data = {"url": signed_download_url}
+    fence_get_signed_url_mocked_request = respx.get(
+        fence_url, status_code=200, content=fence_data
+    )
+
+    # GET an object that exists in indexd but NOT in MDS
+    #  resp = client.get(get_object_url)
+    #  assert indexd_get_mocked_request.called
+    #  assert resp.status_code == 200, resp.text
+    #  assert resp.json() == {"record": indexd_data, "metadata": {}}
+
+    # create metadata for this object
+    #  mds_data = dict(a=1, b=2)
+    #  client.post("/metadata/" + indexd_did, json=mds_data).raise_for_status()
+
+    #  indexd_url = f"{config.INDEXING_SERVICE_ENDPOINT}/{guid}/download"
+    #  indexd_get_mocked_request = respx.get(indexd_url, status_code=200)
+    object_download_url = f"/objects/{guid}/download"
+    # GET an object that exists in indexd AND in MDS
+    try:
+        resp = client.get(object_download_url)
+        #  assert indexd_get_mocked_request.called
+        #  assert resp.status_code == 200, resp.text
+        assert fence_get_signed_url_mocked_request.called
+        assert resp.status_code == 200
+        assert resp.json() == {"download_url": signed_download_url}
+    finally:
+        #  XXX
+        print("ERROR")

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -795,18 +795,21 @@ def test_get_object_not_in_indexd(client):
 
 
 @respx.mock
-def test_get_object_signed_download_url_for_fence_200(
+def test_get_object_signed_download_url_for_data_access_200(
     client, download_endpoints, signed_url_mock
 ):
     """
-    XXX
+    Test that mds returns a 200 containing the signed download url when the
+    data access service download endpoint returns a 200.
     """
-    fence_signed_download_get_request_mock = respx.get(
-        download_endpoints["fence"], status_code=200, content={"url": signed_url_mock}
+    data_access_signed_download_get_request_mock = respx.get(
+        download_endpoints["data_access"],
+        status_code=200,
+        content={"url": signed_url_mock},
     )
 
     resp = client.get(download_endpoints["mds"])
-    assert fence_signed_download_get_request_mock.called
+    assert data_access_signed_download_get_request_mock.called
     assert resp.status_code == 200, resp.text
     resp_json = resp.json()
     assert "guid" in resp_json
@@ -816,64 +819,68 @@ def test_get_object_signed_download_url_for_fence_200(
 
 
 @respx.mock
-def test_get_object_signed_download_url_for_fence_404(
+def test_get_object_signed_download_url_for_data_access_404(
     client, download_endpoints, signed_url_mock
 ):
     """
-    XXX
+    Test that mds returns a 404 when the data access service download endpoint
+    returns a 404.
     """
-    fence_signed_download_get_request_mock = respx.get(
-        download_endpoints["fence"], status_code=404
+    data_access_signed_download_get_request_mock = respx.get(
+        download_endpoints["data_access"], status_code=404
     )
 
     resp = client.get(download_endpoints["mds"])
-    assert fence_signed_download_get_request_mock.called
+    assert data_access_signed_download_get_request_mock.called
     assert resp.status_code == 404, resp.text
 
 
 @respx.mock
-def test_get_object_signed_download_url_for_fence_401(
+def test_get_object_signed_download_url_for_data_access_401(
     client, download_endpoints, signed_url_mock
 ):
     """
-    XXX
+    Test that mds returns a 403 when the data access service download endpoint
+    returns a 401.
     """
-    fence_signed_download_get_request_mock = respx.get(
-        download_endpoints["fence"], status_code=401
+    data_access_signed_download_get_request_mock = respx.get(
+        download_endpoints["data_access"], status_code=401
     )
 
     resp = client.get(download_endpoints["mds"])
-    assert fence_signed_download_get_request_mock.called
+    assert data_access_signed_download_get_request_mock.called
     assert resp.status_code == 403, resp.text
 
 
 @respx.mock
-def test_get_object_signed_download_url_for_fence_403(
+def test_get_object_signed_download_url_for_data_access_403(
     client, download_endpoints, signed_url_mock
 ):
     """
-    XXX
+    Test that mds returns a 403 when the data access service download endpoint
+    returns a 403.
     """
-    fence_signed_download_get_request_mock = respx.get(
-        download_endpoints["fence"], status_code=403
+    data_access_signed_download_get_request_mock = respx.get(
+        download_endpoints["data_access"], status_code=403
     )
 
     resp = client.get(download_endpoints["mds"])
-    assert fence_signed_download_get_request_mock.called
+    assert data_access_signed_download_get_request_mock.called
     assert resp.status_code == 403, resp.text
 
 
 @respx.mock
-def test_get_object_signed_download_url_for_fence_500(
+def test_get_object_signed_download_url_for_data_access_500(
     client, download_endpoints, signed_url_mock
 ):
     """
-    XXX
+    Test that mds returns a 500 when the data access service download endpoint
+    returns a 500.
     """
-    fence_signed_download_get_request_mock = respx.get(
-        download_endpoints["fence"], status_code=500
+    data_access_signed_download_get_request_mock = respx.get(
+        download_endpoints["data_access"], status_code=500
     )
 
     resp = client.get(download_endpoints["mds"])
-    assert fence_signed_download_get_request_mock.called
+    assert data_access_signed_download_get_request_mock.called
     assert resp.status_code == 500, resp.text

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -795,42 +795,85 @@ def test_get_object_not_in_indexd(client):
 
 
 @respx.mock
-def test_get_object_signed_download_url(client):
+def test_get_object_signed_download_url_for_fence_200(
+    client, download_endpoints, signed_url_mock
+):
     """
     XXX
     """
-    guid = "1234"
-    signed_download_url = "https://cats.com/download/paws"
-    #  indexd_did = "test_did"
-
-    #  mock the request to indexd: GUID or alias found in indexd XXX
-    fence_url = f"{config.DATA_ACCESS_SERVICE_ENDPOINT}/data/download/{guid}"
-    fence_data = {"url": signed_download_url}
-    fence_get_signed_url_mocked_request = respx.get(
-        fence_url, status_code=200, content=fence_data
+    fence_signed_download_get_request_mock = respx.get(
+        download_endpoints["fence"], status_code=200, content={"url": signed_url_mock}
     )
 
-    # GET an object that exists in indexd but NOT in MDS
-    #  resp = client.get(get_object_url)
-    #  assert indexd_get_mocked_request.called
-    #  assert resp.status_code == 200, resp.text
-    #  assert resp.json() == {"record": indexd_data, "metadata": {}}
+    resp = client.get(download_endpoints["mds"])
+    assert fence_signed_download_get_request_mock.called
+    assert resp.status_code == 200, resp.text
+    resp_json = resp.json()
+    assert "guid" in resp_json
+    assert "download_url" in resp_json
+    assert resp_json["guid"] == download_endpoints["guid_mock"]
+    assert resp_json["download_url"] == signed_url_mock
 
-    # create metadata for this object
-    #  mds_data = dict(a=1, b=2)
-    #  client.post("/metadata/" + indexd_did, json=mds_data).raise_for_status()
 
-    #  indexd_url = f"{config.INDEXING_SERVICE_ENDPOINT}/{guid}/download"
-    #  indexd_get_mocked_request = respx.get(indexd_url, status_code=200)
-    object_download_url = f"/objects/{guid}/download"
-    # GET an object that exists in indexd AND in MDS
-    try:
-        resp = client.get(object_download_url)
-        #  assert indexd_get_mocked_request.called
-        #  assert resp.status_code == 200, resp.text
-        assert fence_get_signed_url_mocked_request.called
-        assert resp.status_code == 200
-        assert resp.json() == {"download_url": signed_download_url}
-    finally:
-        #  XXX
-        print("ERROR")
+@respx.mock
+def test_get_object_signed_download_url_for_fence_404(
+    client, download_endpoints, signed_url_mock
+):
+    """
+    XXX
+    """
+    fence_signed_download_get_request_mock = respx.get(
+        download_endpoints["fence"], status_code=404
+    )
+
+    resp = client.get(download_endpoints["mds"])
+    assert fence_signed_download_get_request_mock.called
+    assert resp.status_code == 404, resp.text
+
+
+@respx.mock
+def test_get_object_signed_download_url_for_fence_401(
+    client, download_endpoints, signed_url_mock
+):
+    """
+    XXX
+    """
+    fence_signed_download_get_request_mock = respx.get(
+        download_endpoints["fence"], status_code=401
+    )
+
+    resp = client.get(download_endpoints["mds"])
+    assert fence_signed_download_get_request_mock.called
+    assert resp.status_code == 403, resp.text
+
+
+@respx.mock
+def test_get_object_signed_download_url_for_fence_403(
+    client, download_endpoints, signed_url_mock
+):
+    """
+    XXX
+    """
+    fence_signed_download_get_request_mock = respx.get(
+        download_endpoints["fence"], status_code=403
+    )
+
+    resp = client.get(download_endpoints["mds"])
+    assert fence_signed_download_get_request_mock.called
+    assert resp.status_code == 403, resp.text
+
+
+@respx.mock
+def test_get_object_signed_download_url_for_fence_500(
+    client, download_endpoints, signed_url_mock
+):
+    """
+    XXX
+    """
+    fence_signed_download_get_request_mock = respx.get(
+        download_endpoints["fence"], status_code=500
+    )
+
+    resp = client.get(download_endpoints["mds"])
+    assert fence_signed_download_get_request_mock.called
+    assert resp.status_code == 500, resp.text


### PR DESCRIPTION
Jira Ticket: [PXP-5531](https://ctds-planx.atlassian.net/browse/PXP-5531)

### New Features
- Add `GET /objects/{guid}/download` endpoint to proxy a request to Fence to generate a signed download url for the provided guid.
