### PR TITLE
(PXP-5528): implement GET /objects/{guid}/latest

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -545,6 +545,16 @@ paths:
       - Object
   /objects/{guid}/latest:
     get:
+      description: "Attempt to fetch the latest version of the provided guid/key from\
+        \ indexd.\nIf the provided guid/key is found in indexd, return the indexd\
+        \ record and\nmetadata object associated with the latest guid fetched from\
+        \ indexd. If the\nprovided guid/key is not found in indexd, return the metadata\
+        \ object\nassociated with the provided guid/key.\n\nArgs:\n    guid (str):\
+        \ indexd GUID or MDS key. alias is NOT supported because the\n        corresponding\
+        \ endpoint in indexd does not accept alias\n    request (Request): starlette\
+        \ request (which contains reference to FastAPI app)\n\nReturns:\n    200:\
+        \ { \"record\": { indexd record }, \"metadata\": { MDS metadata } }\n    404:\
+        \ if the key is not in indexd and not in MDS"
       operationId: get_object_latest_objects__guid__latest_get
       parameters:
       - in: path

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -543,6 +543,31 @@ paths:
       summary: Get Object Signed Download Url
       tags:
       - Object
+  /objects/{guid}/latest:
+    get:
+      operationId: get_object_latest_objects__guid__latest_get
+      parameters:
+      - in: path
+        name: guid
+        required: true
+        schema:
+          title: Guid
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {}
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Object Latest
+      tags:
+      - Object
   /version:
     get:
       operationId: get_version_version_get

--- a/src/mds/objects.py
+++ b/src/mds/objects.py
@@ -285,6 +285,13 @@ async def get_object_signed_download_url(
     return JSONResponse(response, HTTP_200_OK)
 
 
+@mod.get("/objects/{guid:path}/latest")
+async def get_object_latest(guid: str, request: Request) -> JSONResponse:
+    """"""
+    response = await _get_object_helper(guid, request, latest=True)
+    return response
+
+
 @mod.get("/objects/{guid:path}")
 async def get_object(guid: str, request: Request) -> JSONResponse:
     """
@@ -299,12 +306,25 @@ async def get_object(guid: str, request: Request) -> JSONResponse:
         200: { "record": { indexd record }, "metadata": { MDS metadata } }
         404: if the key is not in indexd and not in MDS
     """
+    response = await _get_object_helper(guid, request, latest=False)
+    return response
+
+
+async def _get_object_helper(
+    guid: str, request: Request, latest: bool = False
+) -> JSONResponse:
+    """"""
     mds_key = guid
 
     # hit indexd's GUID/alias resolution endpoint to get the indexd did
     indexd_record = {}
     try:
-        endpoint = config.INDEXING_SERVICE_ENDPOINT.rstrip("/") + f"/{guid}"
+        #  endpoint = config.INDEXING_SERVICE_ENDPOINT.rstrip("/") + f"/{guid}"
+        endpoint = (
+            config.INDEXING_SERVICE_ENDPOINT.rstrip("/")
+            + f"/index/{guid}"
+            + ("/latest" if latest else "")
+        )
         response = await request.app.async_client.get(endpoint)
         response.raise_for_status()
 

--- a/src/mds/objects.py
+++ b/src/mds/objects.py
@@ -287,7 +287,22 @@ async def get_object_signed_download_url(
 
 @mod.get("/objects/{guid:path}/latest")
 async def get_object_latest(guid: str, request: Request) -> JSONResponse:
-    """"""
+    """
+    Attempt to fetch the latest version of the provided guid/key from indexd.
+    If the provided guid/key is found in indexd, return the indexd record and
+    metadata object associated with the latest guid fetched from indexd. If the
+    provided guid/key is not found in indexd, return the metadata object
+    associated with the provided guid/key.
+
+    Args:
+        guid (str): indexd GUID or MDS key. alias is NOT supported because the
+            corresponding endpoint in indexd does not accept alias
+        request (Request): starlette request (which contains reference to FastAPI app)
+
+    Returns:
+        200: { "record": { indexd record }, "metadata": { MDS metadata } }
+        404: if the key is not in indexd and not in MDS
+    """
     mds_key = guid
     indexd_record = {}
 
@@ -370,8 +385,15 @@ async def get_object(guid: str, request: Request) -> JSONResponse:
 
 
 async def _get_metadata(mds_key: str) -> dict:
-    """"""
-    # query the metadata database
+    """
+    Query the metadata database for mds_key.
+
+    Args:
+        mds_key (str): key used to query the metadata database
+
+    Returns:
+        dict: the object queried from the metadata database
+    """
     mds_metadata = {}
     try:
         logger.debug(f"Querying the metadata database directly for key '{mds_key}'")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,27 +130,13 @@ def latest_setup(client, guid_pair_mock):
         client.delete("/metadata/" + mds_object["guid"]).raise_for_status()
 
 
-@pytest.fixture(
-    scope="function",
-    params=[
-        # guid w/ prefix
-        {
-            "mock_guid": "dg.TEST/87fced8d-b9c8-44b5-946e-c465c8f8f3d6",
-            "mock_signed_url": "https://mock-signed-url",
-        },
-        # guid w/ no prefix
-        {
-            "mock_guid": "87fced8d-b9c8-44b5-946e-c465c8f8f3d6",
-            "mock_signed_url": "https://mock-signed-url",
-        },
-    ],
-)
-def valid_upload_file_patcher(client, request):
+@pytest.fixture(scope="function")
+def valid_upload_file_patcher(client, guid_mock, signed_url_mock):
     patches = []
 
     data_upload_mocked_reponse = {
-        "guid": request.param.get("mock_guid"),
-        "url": request.param.get("mock_signed_url"),
+        "guid": guid_mock,
+        "url": signed_url_mock,
     }
     data_upload_mock = respx.post(
         config.DATA_ACCESS_SERVICE_ENDPOINT.rstrip("/") + f"/data/upload",
@@ -159,16 +145,14 @@ def valid_upload_file_patcher(client, request):
         alias="data_upload",
     )
     data_upload_guid_mock = respx.get(
-        config.DATA_ACCESS_SERVICE_ENDPOINT.rstrip("/")
-        + f"/data/upload/{request.param.get('mock_guid')}",
+        config.DATA_ACCESS_SERVICE_ENDPOINT.rstrip("/") + f"/data/upload/{guid_mock}",
         status_code=200,
         content=data_upload_mocked_reponse,
         alias="data_upload_guid",
     )
 
     create_aliases_mock = respx.post(
-        config.INDEXING_SERVICE_ENDPOINT.rstrip("/")
-        + f"/index/{request.param.get('mock_guid')}/aliases",
+        config.INDEXING_SERVICE_ENDPOINT.rstrip("/") + f"/index/{guid_mock}/aliases",
         status_code=200,
         alias="create_aliases",
     )
@@ -193,28 +177,20 @@ def valid_upload_file_patcher(client, request):
         "data_upload_mocked_reponse": data_upload_mocked_reponse,
     }
 
-    client.delete(f"/metadata/{request.param.get('mock_guid')}")
+    client.delete(f"/metadata/{guid_mock}")
     for patched_function in patches:
         patched_function.stop()
 
 
-@pytest.fixture(
-    scope="function",
-    params=[
-        {
-            "mock_guid": "dg.TEST/87fced8d-b9c8-44b5-946e-c465c8f8f3d6",
-            "mock_signed_url": "https://mock-signed-url",
-        }
-    ],
-)
-def no_authz_upload_file_patcher(client, request):
+@pytest.fixture(scope="function")
+def no_authz_upload_file_patcher(client, guid_mock, signed_url_mock):
     """
     Same as valid_upload_file_patcher except /data/upload requests are mocked
     as returning a 403 for invalid authz
     """
     patches = []
 
-    data_upload_mocked_reponse = {"guid": request.param.get("mock_guid")}
+    data_upload_mocked_reponse = {"guid": guid_mock}
     data_upload_mock = respx.post(
         config.DATA_ACCESS_SERVICE_ENDPOINT.rstrip("/") + f"/data/upload",
         status_code=403,
@@ -222,16 +198,14 @@ def no_authz_upload_file_patcher(client, request):
         alias="data_upload",
     )
     data_upload_guid_mock = respx.get(
-        config.DATA_ACCESS_SERVICE_ENDPOINT.rstrip("/")
-        + f"/data/upload/{request.param.get('mock_guid')}",
+        config.DATA_ACCESS_SERVICE_ENDPOINT.rstrip("/") + f"/data/upload/{guid_mock}",
         status_code=403,
         content=data_upload_mocked_reponse,
         alias="data_upload_guid",
     )
 
     create_aliases_mock = respx.post(
-        config.INDEXING_SERVICE_ENDPOINT.rstrip("/")
-        + f"/index/{request.param.get('mock_guid')}/aliases",
+        config.INDEXING_SERVICE_ENDPOINT.rstrip("/") + f"/index/{guid_mock}/aliases",
         status_code=200,
         alias="create_aliases",
     )
@@ -256,21 +230,13 @@ def no_authz_upload_file_patcher(client, request):
         "data_upload_mocked_reponse": data_upload_mocked_reponse,
     }
 
-    client.delete(f"/metadata/{request.param.get('mock_guid')}")
+    client.delete(f"/metadata/{guid_mock}")
     for patched_function in patches:
         patched_function.stop()
 
 
-@pytest.fixture(
-    scope="function",
-    params=[
-        {
-            "mock_guid": "dg.TEST/87fced8d-b9c8-44b5-946e-c465c8f8f3d6",
-            "mock_signed_url": "https://mock-signed-url",
-        }
-    ],
-)
-def no_authz_create_aliases_patcher(client, request):
+@pytest.fixture(scope="function")
+def no_authz_create_aliases_patcher(client, guid_mock, signed_url_mock):
     """
     Same as valid_upload_file_patcher except /aliases requests are mocked
     as returning a 403 for invalid authz
@@ -278,8 +244,8 @@ def no_authz_create_aliases_patcher(client, request):
     patches = []
 
     data_upload_mocked_reponse = {
-        "guid": request.param.get("mock_guid"),
-        "url": request.param.get("mock_signed_url"),
+        "guid": guid_mock,
+        "url": signed_url_mock,
     }
     data_upload_mock = respx.post(
         config.DATA_ACCESS_SERVICE_ENDPOINT.rstrip("/") + f"/data/upload",
@@ -289,8 +255,7 @@ def no_authz_create_aliases_patcher(client, request):
     )
 
     create_aliases_mock = respx.post(
-        config.INDEXING_SERVICE_ENDPOINT.rstrip("/")
-        + f"/index/{request.param.get('mock_guid')}/aliases",
+        config.INDEXING_SERVICE_ENDPOINT.rstrip("/") + f"/index/{guid_mock}/aliases",
         status_code=403,
         alias="create_aliases",
     )
@@ -314,22 +279,13 @@ def no_authz_create_aliases_patcher(client, request):
         "data_upload_mocked_reponse": data_upload_mocked_reponse,
     }
 
-    client.delete(f"/metadata/{request.param.get('mock_guid')}")
+    client.delete(f"/metadata/{guid_mock}")
     for patched_function in patches:
         patched_function.stop()
 
 
-@pytest.fixture(
-    scope="function",
-    params=[
-        # guid w/ prefix
-        {
-            "mock_guid": "dg.TEST/87fced8d-b9c8-44b5-946e-c465c8f8f3d6",
-            "mock_signed_url": "https://mock-signed-url",
-        }
-    ],
-)
-def upload_failure_file_patcher(client, request):
+@pytest.fixture(scope="function")
+def upload_failure_file_patcher(client, guid_mock):
     """
     Same as valid_upload_file_patcher except /data/upload requests are mocked
     as returning a 500
@@ -345,8 +301,7 @@ def upload_failure_file_patcher(client, request):
     )
 
     create_aliases_mock = respx.post(
-        config.INDEXING_SERVICE_ENDPOINT.rstrip("/")
-        + f"/index/{request.param.get('mock_guid')}/aliases",
+        config.INDEXING_SERVICE_ENDPOINT.rstrip("/") + f"/index/{guid_mock}/aliases",
         status_code=200,
         alias="create_aliases",
     )
@@ -370,22 +325,13 @@ def upload_failure_file_patcher(client, request):
         "data_upload_mocked_reponse": data_upload_mocked_reponse,
     }
 
-    client.delete(f"/metadata/{request.param.get('mock_guid')}")
+    client.delete(f"/metadata/{guid_mock}")
     for patched_function in patches:
         patched_function.stop()
 
 
-@pytest.fixture(
-    scope="function",
-    params=[
-        # guid w/ prefix
-        {
-            "mock_guid": "dg.TEST/87fced8d-b9c8-44b5-946e-c465c8f8f3d6",
-            "mock_signed_url": "https://mock-signed-url",
-        }
-    ],
-)
-def create_aliases_failure_patcher(client, request):
+@pytest.fixture(scope="function")
+def create_aliases_failure_patcher(client, guid_mock, signed_url_mock):
     """
     Same as valid_upload_file_patcher except /aliases requests are mocked
     as returning a 500
@@ -393,8 +339,8 @@ def create_aliases_failure_patcher(client, request):
     patches = []
 
     data_upload_mocked_reponse = {
-        "guid": request.param.get("mock_guid"),
-        "url": request.param.get("mock_signed_url"),
+        "guid": guid_mock,
+        "url": signed_url_mock,
     }
     data_upload_mock = respx.post(
         config.DATA_ACCESS_SERVICE_ENDPOINT.rstrip("/") + f"/data/upload",
@@ -404,8 +350,7 @@ def create_aliases_failure_patcher(client, request):
     )
 
     create_aliases_mock = respx.post(
-        config.INDEXING_SERVICE_ENDPOINT.rstrip("/")
-        + f"/index/{request.param.get('mock_guid')}/aliases",
+        config.INDEXING_SERVICE_ENDPOINT.rstrip("/") + f"/index/{guid_mock}/aliases",
         status_code=500,
         alias="create_aliases",
     )
@@ -429,22 +374,13 @@ def create_aliases_failure_patcher(client, request):
         "data_upload_mocked_reponse": data_upload_mocked_reponse,
     }
 
-    client.delete(f"/metadata/{request.param.get('mock_guid')}")
+    client.delete(f"/metadata/{guid_mock}")
     for patched_function in patches:
         patched_function.stop()
 
 
-@pytest.fixture(
-    scope="function",
-    params=[
-        # guid w/ prefix
-        {
-            "mock_guid": "dg.TEST/87fced8d-b9c8-44b5-946e-c465c8f8f3d6",
-            "mock_signed_url": "https://mock-signed-url",
-        }
-    ],
-)
-def create_aliases_duplicate_patcher(client, request):
+@pytest.fixture(scope="function")
+def create_aliases_duplicate_patcher(client, guid_mock, signed_url_mock):
     """
     Same as valid_upload_file_patcher except /aliases requests are mocked
     as returning a 500
@@ -452,8 +388,8 @@ def create_aliases_duplicate_patcher(client, request):
     patches = []
 
     data_upload_mocked_reponse = {
-        "guid": request.param.get("mock_guid"),
-        "url": request.param.get("mock_signed_url"),
+        "guid": guid_mock,
+        "url": signed_url_mock,
     }
     data_upload_mock = respx.post(
         config.DATA_ACCESS_SERVICE_ENDPOINT.rstrip("/") + f"/data/upload",
@@ -463,8 +399,7 @@ def create_aliases_duplicate_patcher(client, request):
     )
 
     create_aliases_mock = respx.post(
-        config.INDEXING_SERVICE_ENDPOINT.rstrip("/")
-        + f"/index/{request.param.get('mock_guid')}/aliases",
+        config.INDEXING_SERVICE_ENDPOINT.rstrip("/") + f"/index/{guid_mock}/aliases",
         status_code=409,
         alias="create_aliases",
     )
@@ -488,6 +423,6 @@ def create_aliases_duplicate_patcher(client, request):
         "data_upload_mocked_reponse": data_upload_mocked_reponse,
     }
 
-    client.delete(f"/metadata/{request.param.get('mock_guid')}")
+    client.delete(f"/metadata/{guid_mock}")
     for patched_function in patches:
         patched_function.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,57 @@ def download_endpoints(guid_mock):
 
 
 @pytest.fixture(
+    params=[
+        {
+            "oldest": "934a05a1-993c-4ae0-bfd9-ae9239bba21d",
+            "latest": "2c9975f7-ec98-42fc-a703-a2ce88b1dbcf",
+        },
+        {
+            "oldest": "dg.TEST/fd851a55-3d0b-485d-b1c9-66acb8791de7",
+            "latest": "dg.TEST/19010a4e-53f9-4a27-b69f-26fc73089a52",
+        },
+        {
+            "oldest": "e900cb8b-eb4f-4fb8-af74-e3e02515a224",
+            "latest": "dg.TEST/ddcd4f3a-9450-4e85-bd5c-39d958617a5c",
+        },
+        {
+            "oldest": "dg.TEST/00bff671-5fc6-490b-9c38-f07a41655c1f",
+            "latest": "438f82ac-1f7e-4b94-8ac1-ca7e55ada5de",
+        },
+    ]
+)
+def guid_pair_mock(request):
+    """"""
+    yield request.param
+
+
+@pytest.fixture()
+def get_objects_guid_latest_setup(client, guid_pair_mock):
+    setup = {
+        "oldest_guid": guid_pair_mock["oldest"],
+        "latest_guid": guid_pair_mock["latest"],
+        "mds_endpoint": f"/objects/{guid_pair_mock['oldest']}/latest",
+        "indexd_endpoint": f"{config.INDEXING_SERVICE_ENDPOINT}/index/{guid_pair_mock['oldest']}/latest",
+        "mds_objects": {
+            "oldest": {"guid": guid_pair_mock["oldest"], "data": dict(a=1, b=2)},
+            "latest": {"guid": guid_pair_mock["latest"], "data": dict(a=3, b=4)},
+        },
+    }
+    #  for mds_object in mds_objects.values():
+    #  client.post("/metadata/" + mds_object["key"], json=mds_object["data"]).raise_for_status()
+    for mds_object in setup["mds_objects"].values():
+        client.post(
+            "/metadata/" + mds_object["guid"], json=mds_object["data"]
+        ).raise_for_status()
+
+    #  yield mds_objects
+    yield setup
+
+    for mds_object in setup["mds_objects"].values():
+        client.delete("/metadata/" + mds_object["guid"]).raise_for_status()
+
+
+@pytest.fixture(
     scope="function",
     params=[
         # guid w/ prefix

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,13 +101,39 @@ def guid_pair_mock(request):
     yield request.param
 
 
+@pytest.fixture(params=["test_alias", "testAlias", "test-alias-123"])
+def alias_mock(request):
+    """"""
+    yield request.param
+
+
 @pytest.fixture()
-def get_objects_guid_latest_setup(client, guid_pair_mock):
+def latest_setup(client, guid_pair_mock, alias_mock):
+    non_mds_guid = "3507f4e5-e6f7-4ffa-b9fa-c82d0c16de91"
     setup = {
         "oldest_guid": guid_pair_mock["oldest"],
         "latest_guid": guid_pair_mock["latest"],
-        "mds_endpoint": f"/objects/{guid_pair_mock['oldest']}/latest",
-        "indexd_endpoint": f"{config.INDEXING_SERVICE_ENDPOINT}/index/{guid_pair_mock['oldest']}/latest",
+        "non_mds_guid": non_mds_guid,
+        "alias": alias_mock,
+        "mds_latest_endpoint_with_oldest_guid": f"/objects/{guid_pair_mock['oldest']}/latest",
+        "mds_latest_endpoint_with_non_mds_guid": f"/objects/{non_mds_guid}/latest",
+        "mds_latest_endpoint_with_alias": f"/objects/{alias_mock}/latest",
+        "indexd_resolution_endpoint_with_oldest_guid": f"{config.INDEXING_SERVICE_ENDPOINT}/{guid_pair_mock['oldest']}",
+        "indexd_resolution_endpoint_with_non_mds_guid": f"{config.INDEXING_SERVICE_ENDPOINT}/{non_mds_guid}",
+        "indexd_resolution_endpoint_with_alias": f"{config.INDEXING_SERVICE_ENDPOINT}/{alias_mock}",
+        "indexd_latest_endpoint_with_oldest_guid": f"{config.INDEXING_SERVICE_ENDPOINT}/index/{guid_pair_mock['oldest']}/latest",
+        "indexd_oldest_record_data": {
+            "did": guid_pair_mock["oldest"],
+            "size": 314,
+        },
+        "indexd_latest_record_data": {
+            "did": guid_pair_mock["latest"],
+            "size": 42,
+        },
+        "indexd_non_mds_record_data": {
+            "did": non_mds_guid,
+            "size": 271,
+        },
         "mds_objects": {
             "oldest": {"guid": guid_pair_mock["oldest"], "data": dict(a=1, b=2)},
             "latest": {"guid": guid_pair_mock["latest"], "data": dict(a=3, b=4)},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,12 +89,19 @@ def download_endpoints(guid_mock):
     ]
 )
 def guid_pair_mock(request):
-    """"""
+    """
+    Yields oldest/latest pair of guids that are intended to be used such that
+    they have the same baseid in indexd.
+    """
     yield request.param
 
 
 @pytest.fixture()
 def latest_setup(client, guid_pair_mock):
+    """
+    Yields both indexd latest endpoints and associated records, and mds latest
+    endpoints and associated persisted objects.
+    """
     non_mds_guid = "3507f4e5-e6f7-4ffa-b9fa-c82d0c16de91"
     setup = {
         "mds_latest_endpoint_with_oldest_guid": f"/objects/{guid_pair_mock['oldest']}/latest",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,14 +86,6 @@ def download_endpoints(guid_mock):
             "oldest": "dg.TEST/fd851a55-3d0b-485d-b1c9-66acb8791de7",
             "latest": "dg.TEST/19010a4e-53f9-4a27-b69f-26fc73089a52",
         },
-        {
-            "oldest": "e900cb8b-eb4f-4fb8-af74-e3e02515a224",
-            "latest": "dg.TEST/ddcd4f3a-9450-4e85-bd5c-39d958617a5c",
-        },
-        {
-            "oldest": "dg.TEST/00bff671-5fc6-490b-9c38-f07a41655c1f",
-            "latest": "438f82ac-1f7e-4b94-8ac1-ca7e55ada5de",
-        },
     ]
 )
 def guid_pair_mock(request):
@@ -101,27 +93,14 @@ def guid_pair_mock(request):
     yield request.param
 
 
-@pytest.fixture(params=["test_alias", "testAlias", "test-alias-123"])
-def alias_mock(request):
-    """"""
-    yield request.param
-
-
 @pytest.fixture()
-def latest_setup(client, guid_pair_mock, alias_mock):
+def latest_setup(client, guid_pair_mock):
     non_mds_guid = "3507f4e5-e6f7-4ffa-b9fa-c82d0c16de91"
     setup = {
-        "oldest_guid": guid_pair_mock["oldest"],
-        "latest_guid": guid_pair_mock["latest"],
-        "non_mds_guid": non_mds_guid,
-        "alias": alias_mock,
         "mds_latest_endpoint_with_oldest_guid": f"/objects/{guid_pair_mock['oldest']}/latest",
         "mds_latest_endpoint_with_non_mds_guid": f"/objects/{non_mds_guid}/latest",
-        "mds_latest_endpoint_with_alias": f"/objects/{alias_mock}/latest",
-        "indexd_resolution_endpoint_with_oldest_guid": f"{config.INDEXING_SERVICE_ENDPOINT}/{guid_pair_mock['oldest']}",
-        "indexd_resolution_endpoint_with_non_mds_guid": f"{config.INDEXING_SERVICE_ENDPOINT}/{non_mds_guid}",
-        "indexd_resolution_endpoint_with_alias": f"{config.INDEXING_SERVICE_ENDPOINT}/{alias_mock}",
         "indexd_latest_endpoint_with_oldest_guid": f"{config.INDEXING_SERVICE_ENDPOINT}/index/{guid_pair_mock['oldest']}/latest",
+        "indexd_latest_endpoint_with_non_mds_guid": f"{config.INDEXING_SERVICE_ENDPOINT}/index/{non_mds_guid}/latest",
         "indexd_oldest_record_data": {
             "did": guid_pair_mock["oldest"],
             "size": 314,
@@ -139,14 +118,12 @@ def latest_setup(client, guid_pair_mock, alias_mock):
             "latest": {"guid": guid_pair_mock["latest"], "data": dict(a=3, b=4)},
         },
     }
-    #  for mds_object in mds_objects.values():
-    #  client.post("/metadata/" + mds_object["key"], json=mds_object["data"]).raise_for_status()
+
     for mds_object in setup["mds_objects"].values():
         client.post(
             "/metadata/" + mds_object["guid"], json=mds_object["data"]
         ).raise_for_status()
 
-    #  yield mds_objects
     yield setup
 
     for mds_object in setup["mds_objects"].values():

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -882,3 +882,35 @@ def test_get_object_signed_download_url_for_data_access_500(
     resp = client.get(download_endpoints["mds"])
     assert data_access_signed_download_get_request_mock.called
     assert resp.status_code == 500, resp.text
+
+
+@respx.mock
+def test_get_object_latest_for_indexd_200(client, get_objects_guid_latest_setup):
+    """"""
+    latest_indexd_record_data = {
+        "did": get_objects_guid_latest_setup["latest_guid"],
+        "size": 42,
+    }
+    indexd_guid_latest_get_request_mock = respx.get(
+        get_objects_guid_latest_setup["indexd_endpoint"],
+        status_code=200,
+        content=latest_indexd_record_data,
+    )
+
+    resp = client.get(get_objects_guid_latest_setup["mds_endpoint"])
+    assert indexd_guid_latest_get_request_mock.called
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "record": latest_indexd_record_data,
+        "metadata": get_objects_guid_latest_setup["mds_objects"]["latest"]["data"],
+    }
+
+
+#  @respx.mock
+#  def test_get_object_latest_for_indexd_404(
+#  client, latest_endpoints, metadata_service_objects
+#  ):
+#  """
+#  """
+#  import pdb; pdb.set_trace()
+#  pass

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -885,15 +885,10 @@ def test_get_object_signed_download_url_for_data_access_500(
 
 
 @respx.mock
-def test_get_object_latest_when_resolving_guid_and_indexd_latest_returns_200(
+def test_get_object_latest_when_indexd_returns_different_guid_and_different_guid_in_mds(
     client, latest_setup
 ):
     """"""
-    get_indexd_resolution_request_mock = respx.get(
-        latest_setup["indexd_resolution_endpoint_with_oldest_guid"],
-        status_code=200,
-        content=latest_setup["indexd_oldest_record_data"],
-    )
     get_indexd_latest_request_mock = respx.get(
         latest_setup["indexd_latest_endpoint_with_oldest_guid"],
         status_code=200,
@@ -901,7 +896,6 @@ def test_get_object_latest_when_resolving_guid_and_indexd_latest_returns_200(
     )
 
     resp = client.get(latest_setup["mds_latest_endpoint_with_oldest_guid"])
-    assert get_indexd_resolution_request_mock.called
     assert get_indexd_latest_request_mock.called
     assert resp.status_code == 200, resp.text
     assert resp.json() == {
@@ -911,49 +905,17 @@ def test_get_object_latest_when_resolving_guid_and_indexd_latest_returns_200(
 
 
 @respx.mock
-def test_get_object_latest_when_resolving_alias_and_indexd_latest_returns_different_record(
+def test_get_object_latest_when_indexd_returns_same_guid_and_same_guid_in_mds(
     client, latest_setup
 ):
     """"""
-    get_indexd_resolution_request_mock = respx.get(
-        latest_setup["indexd_resolution_endpoint_with_alias"],
-        status_code=200,
-        content=latest_setup["indexd_oldest_record_data"],
-    )
-    get_indexd_latest_request_mock = respx.get(
-        latest_setup["indexd_latest_endpoint_with_oldest_guid"],
-        status_code=200,
-        content=latest_setup["indexd_latest_record_data"],
-    )
-
-    resp = client.get(latest_setup["mds_latest_endpoint_with_alias"])
-    assert get_indexd_resolution_request_mock.called
-    assert get_indexd_latest_request_mock.called
-    assert resp.status_code == 200, resp.text
-    assert resp.json() == {
-        "record": latest_setup["indexd_latest_record_data"],
-        "metadata": latest_setup["mds_objects"]["latest"]["data"],
-    }
-
-
-@respx.mock
-def test_get_object_latest_when_resolving_alias_and_indexd_latest_returns_same_record(
-    client, latest_setup
-):
-    """"""
-    get_indexd_resolution_request_mock = respx.get(
-        latest_setup["indexd_resolution_endpoint_with_alias"],
-        status_code=200,
-        content=latest_setup["indexd_oldest_record_data"],
-    )
     get_indexd_latest_request_mock = respx.get(
         latest_setup["indexd_latest_endpoint_with_oldest_guid"],
         status_code=200,
         content=latest_setup["indexd_oldest_record_data"],
     )
 
-    resp = client.get(latest_setup["mds_latest_endpoint_with_alias"])
-    assert get_indexd_resolution_request_mock.called
+    resp = client.get(latest_setup["mds_latest_endpoint_with_oldest_guid"])
     assert get_indexd_latest_request_mock.called
     assert resp.status_code == 200, resp.text
     assert resp.json() == {
@@ -963,15 +925,8 @@ def test_get_object_latest_when_resolving_alias_and_indexd_latest_returns_same_r
 
 
 @respx.mock
-def test_get_object_latest_when_resolving_guid_and_indexd_latest_returns_guid_not_in_mds(
-    client, latest_setup
-):
+def test_get_object_latest_when_indexd_returns_guid_not_in_mds(client, latest_setup):
     """"""
-    get_indexd_resolution_request_mock = respx.get(
-        latest_setup["indexd_resolution_endpoint_with_oldest_guid"],
-        status_code=200,
-        content=latest_setup["indexd_oldest_record_data"],
-    )
     get_indexd_latest_request_mock = respx.get(
         latest_setup["indexd_latest_endpoint_with_oldest_guid"],
         status_code=200,
@@ -979,7 +934,6 @@ def test_get_object_latest_when_resolving_guid_and_indexd_latest_returns_guid_no
     )
 
     resp = client.get(latest_setup["mds_latest_endpoint_with_oldest_guid"])
-    assert get_indexd_resolution_request_mock.called
     assert get_indexd_latest_request_mock.called
     assert resp.status_code == 200, resp.text
     assert resp.json() == {
@@ -989,22 +943,17 @@ def test_get_object_latest_when_resolving_guid_and_indexd_latest_returns_guid_no
 
 
 @respx.mock
-def test_get_object_latest_when_indexd_resolution_returns_404_but_guid_in_mds(
+def test_get_object_latest_when_indexd_returns_404_but_guid_in_mds(
     client, latest_setup
 ):
     """"""
-    get_indexd_resolution_request_mock = respx.get(
-        latest_setup["indexd_resolution_endpoint_with_oldest_guid"],
-        status_code=404,
-    )
     get_indexd_latest_request_mock = respx.get(
         latest_setup["indexd_latest_endpoint_with_oldest_guid"],
         status_code=404,
     )
 
     resp = client.get(latest_setup["mds_latest_endpoint_with_oldest_guid"])
-    assert get_indexd_resolution_request_mock.called
-    assert not get_indexd_latest_request_mock.called
+    assert get_indexd_latest_request_mock.called
     assert resp.status_code == 200, resp.text
     assert resp.json() == {
         "record": {},
@@ -1013,15 +962,33 @@ def test_get_object_latest_when_indexd_resolution_returns_404_but_guid_in_mds(
 
 
 @respx.mock
-def test_get_object_latest_when_indexd_resolution_returns_404_and_guid_not_in_mds(
+def test_get_object_latest_when_indexd_returns_500_but_guid_in_mds(
     client, latest_setup
 ):
     """"""
-    get_indexd_resolution_request_mock = respx.get(
-        latest_setup["indexd_resolution_endpoint_with_non_mds_guid"],
-        status_code=404,
+    get_indexd_latest_request_mock = respx.get(
+        latest_setup["indexd_latest_endpoint_with_oldest_guid"],
+        status_code=500,
     )
 
+    resp = client.get(latest_setup["mds_latest_endpoint_with_oldest_guid"])
+    assert get_indexd_latest_request_mock.called
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "record": {},
+        "metadata": latest_setup["mds_objects"]["oldest"]["data"],
+    }
+
+
+@respx.mock
+def test_get_object_latest_when_indexd_returns_404_and_guid_not_in_mds(
+    client, latest_setup
+):
+    """"""
+    get_indexd_latest_request_mock = respx.get(
+        latest_setup["indexd_latest_endpoint_with_non_mds_guid"],
+        status_code=404,
+    )
     resp = client.get(latest_setup["mds_latest_endpoint_with_non_mds_guid"])
-    assert get_indexd_resolution_request_mock.called
+    assert get_indexd_latest_request_mock.called
     assert resp.status_code == 404, resp.text

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -888,7 +888,12 @@ def test_get_object_signed_download_url_for_data_access_500(
 def test_get_object_latest_when_indexd_returns_different_guid_and_different_guid_in_mds(
     client, latest_setup
 ):
-    """"""
+    """
+    Test that mds returns a 200 containing an indexd record and mds object
+    associated with the guid returned from indexd's latest endpoint (in this
+    case, that latest guid returned from indexd is different to the oldest guid
+    initially provided to the mds latest endpoint).
+    """
     get_indexd_latest_request_mock = respx.get(
         latest_setup["indexd_latest_endpoint_with_oldest_guid"],
         status_code=200,
@@ -908,7 +913,12 @@ def test_get_object_latest_when_indexd_returns_different_guid_and_different_guid
 def test_get_object_latest_when_indexd_returns_same_guid_and_same_guid_in_mds(
     client, latest_setup
 ):
-    """"""
+    """
+    Test that mds returns a 200 containing an indexd record and mds object
+    associated with the guid initially provided to the mds latest endpoint (in
+    this case, indexd's latest endpoint returns a guid that is the same as the
+    one intially provided to the mds latest endpoint).
+    """
     get_indexd_latest_request_mock = respx.get(
         latest_setup["indexd_latest_endpoint_with_oldest_guid"],
         status_code=200,
@@ -926,7 +936,12 @@ def test_get_object_latest_when_indexd_returns_same_guid_and_same_guid_in_mds(
 
 @respx.mock
 def test_get_object_latest_when_indexd_returns_guid_not_in_mds(client, latest_setup):
-    """"""
+    """
+    Test that mds returns a 200 containing an indexd record associated with the
+    guid returned from the indexd latest endpoint and an empty metadata object
+    (in this case, the indexd latest endpoint returns a guid that is not a key
+    in the mds database).
+    """
     get_indexd_latest_request_mock = respx.get(
         latest_setup["indexd_latest_endpoint_with_oldest_guid"],
         status_code=200,
@@ -946,7 +961,11 @@ def test_get_object_latest_when_indexd_returns_guid_not_in_mds(client, latest_se
 def test_get_object_latest_when_indexd_returns_404_but_guid_in_mds(
     client, latest_setup
 ):
-    """"""
+    """
+    Test that mds returns a 200 containing an empty indexd record and a
+    metadata object associated with the guid/key intially provided to the mds
+    latest endpoint (in this case, indexd's latest endpoint returns a 404).
+    """
     get_indexd_latest_request_mock = respx.get(
         latest_setup["indexd_latest_endpoint_with_oldest_guid"],
         status_code=404,
@@ -965,7 +984,11 @@ def test_get_object_latest_when_indexd_returns_404_but_guid_in_mds(
 def test_get_object_latest_when_indexd_returns_500_but_guid_in_mds(
     client, latest_setup
 ):
-    """"""
+    """
+    Test that mds returns a 200 containing an empty indexd record and a
+    metadata object associated with the guid/key intially provided to the mds
+    latest endpoint (in this case, indexd's latest endpoint returns a 500).
+    """
     get_indexd_latest_request_mock = respx.get(
         latest_setup["indexd_latest_endpoint_with_oldest_guid"],
         status_code=500,
@@ -984,7 +1007,11 @@ def test_get_object_latest_when_indexd_returns_500_but_guid_in_mds(
 def test_get_object_latest_when_indexd_returns_404_and_guid_not_in_mds(
     client, latest_setup
 ):
-    """"""
+    """
+    Test that mds returns a 404 when indexd's latest endpoint returns a 404 and
+    the guid/key intially provided to the mds latest endpoint is not in the mds
+    database.
+    """
     get_indexd_latest_request_mock = respx.get(
         latest_setup["indexd_latest_endpoint_with_non_mds_guid"],
         status_code=404,


### PR DESCRIPTION
Jira Ticket: [PXP-5528](https://ctds-planx.atlassian.net/browse/PXP-5528)

Implement `GET /objects/{guid}/latest` endpoint.

### New Features
- Add `GET /objects/{guid}/latest` endpoint that returns the Indexd record and MDS object associated with the latest version of `guid` fetched from Indexd.

### Improvements
- Use `guid_mock` and `signed_url_mock` for repeated guids and signed urls in `tests/conftest.py`