### PR TITLE
chore(mds): Adopt parent img from quay to avoid pull rate limit errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine as base
+FROM quay.io/cdis/python:3.7-alpine as base
 
 FROM base as builder
 RUN apk add --no-cache --virtual .build-deps gcc musl-dev libffi-dev openssl-dev make postgresql-dev git curl


### PR DESCRIPTION
Unblocking release202101 by avoiding the following error in Quay:
```
Could not pull base image: API error (500): toomanyrequests: You have reached your pull rate limit. 
You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

### Improvements
- Adopt quay.io image to avoid `API error (500): toomanyrequests` produced by Dockerhub.