### PR TITLE
fix(docker-compose): update compose config, docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,13 @@ RUN apk add --no-cache --virtual .build-deps gcc musl-dev libffi-dev openssl-dev
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
 COPY . /src/
 WORKDIR /src
-RUN python -m venv /env && . /env/bin/activate && $HOME/.poetry/bin/poetry install --no-dev --no-interaction
+RUN python -m venv /env && . /env/bin/activate && $HOME/.poetry/bin/poetry install --no-interaction
 
 FROM base
 RUN apk add --no-cache postgresql-libs
+COPY --from=builder /root/.poetry /root/.poetry
 COPY --from=builder /env /env
 COPY --from=builder /src /src
+ENV PATH="/env/bin/:${PATH}"
 WORKDIR /src
 CMD ["/env/bin/gunicorn", "mds.asgi:app", "-b", "0.0.0.0:80", "-k", "uvicorn.workers.UvicornWorker", "-c", "gunicorn.conf.py"]

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The server is built with [FastAPI](https://fastapi.tiangolo.com/) and packaged w
 
 Install required software:
 
-*   [PostgreSQL](PostgreSQL) 9.6 or above
-*   [Python](https://www.python.org/downloads/) 3.7 or above
-*   [Poetry](https://poetry.eustace.io/docs/#installation)
+* [PostgreSQL](PostgreSQL) 9.6 or above
+* [Python](https://www.python.org/downloads/) 3.7 or above
+* [Poetry](https://poetry.eustace.io/docs/#installation)
 
 Then use `poetry install` to install the dependencies. Before that,
 a [virtualenv](https://virtualenv.pypa.io/) is recommended.
@@ -78,19 +78,13 @@ docker-compose up
 Run database schema migration as well:
 
 ```bash
-docker-compose exec mds poetry run alembic upgrade head
-```
-
-Create test database:
-
-```bash
-docker-compose exec db createdb -U mds test_mds
+docker-compose exec app alembic upgrade head
 ```
 
 Run tests:
 
 ```bash
-docker-compose exec mds poetry run pytest --cov=src --cov=migrations/versions tests
+docker-compose exec app pytest --cov=src --cov=migrations/versions tests
 ```
 
 ## Deployment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,5 +27,7 @@ services:
     image: postgres
     environment:
       - POSTGRES_USER=mds
+      - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - ./postgres-data:/var/lib/postgresql/data
+      - ./postgres-init:/docker-entrypoint-initdb.d:ro

--- a/postgres-init/init.sh
+++ b/postgres-init/init.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+createdb -U mds test_mds


### PR DESCRIPTION
### New Features

* add `init.sh` script for `docker-compose` to automatically create the test DB

### Bug Fixes

* add `POSTGRES_HOST_AUTH_METHOD` config in `docker-compose` to fix an error on postgres initialization
* remove `--no-dev` from `poetry install` so that `pytest` and other dev dependencies are in the docker image

### Improvements

* `docker-compose` update to add the `PATH` for app binaries at `/env`, which removes the need for `poetry run` prefixes on some commands
