### PR TITLE
chore(configs): remove configs from source control

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - .:/src
     environment:
       - USE_AGG_MDS=true
-    command: /env/bin/python /src/src/mds/populate.py --config /src/configs/brh_config.json --hostname esproxy-service --port 9200
+    command: /env/bin/python /src/src/mds/populate.py --config /src/tests/config.json --hostname esproxy-service --port 9200
   db:
     image: postgres
     environment:

--- a/src/mds/agg_mds/adapters.py
+++ b/src/mds/agg_mds/adapters.py
@@ -498,8 +498,8 @@ class Gen3Adapter(RemoteMetadataAdapter):
         limit = min(maxItems, batchSize) if maxItems is not None else batchSize
         moreData = True
         while moreData:
+            url = f"{mds_url}mds/metadata?data=True&_guid_type={guid_type}&limit={limit}&offset={offset}"
             try:
-                url = f"{mds_url}mds/metadata?data=True&_guid_type={guid_type}&limit={limit}&offset={offset}"
                 if field_name is not None and field_value is not None:
                     url += f"&{guid_type}.{field_name}={field_value}"
                 response = httpx.get(url)
@@ -516,11 +516,9 @@ class Gen3Adapter(RemoteMetadataAdapter):
                         f"{response.status_code} error occurred while requesting {self.mds_url}."
                     )
                     raise ValueError(f"An error occurred while requesting {mds_url}.")
-            except httpx.RequestError as exc:
-                logger.error(f"An error occurred while requesting {exc.request.url}.")
-                raise ValueError(
-                    f"An error occurred while requesting {exc.request.url}."
-                )
+            except Exception as exc:
+                logger.error(f"An error occurred while requesting {url}.")
+                raise ValueError(f"An error occurred while requesting {url}.")
 
         return results
 

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,78 +1,57 @@
 {
-	"BioData Catalyst": {
-		"mds_url": "https://staging.gen3.biodatacatalyst.nhlbi.nih.gov",
-		"commons_url" : "gen3.biodatacatalyst.nhlbi.nih.gov",
-		"columns_to_fields": {
-			"short_name": "name",
-			"full_name": "full_name",
-			"_subjects_count" : "_subjects_count",
-			"study_id" : "study_id",
-			"_unique_id" : "_unique_id",
-			"study_description" : "study_description"
-		}
-	},
-	"AnVIL": {
-		"mds_url": "https://internalstaging.theanvil.io",
-		"commons_url": "gen3.theanvil.io",
-		"columns_to_fields": {
-			"name": "name",
-			"full_name": "full_name",
-			"_subjects_count" : "_subjects_count",
-			"study_id" : "study_id",
-			"study_description" : "study_description"
-		}
-	},
-	"HEAL": {
-		"mds_url": "https://preprod.healdata.org",
-		"commons_url": "preprod.healdata.org",
-		"columns_to_fields": {
-			"study_name": "name",
-			"project_title": "full_name",
-			"project_number" : "study_id",
-			"_unique_id" : "study_id",
-			"summary" : "study_description"
-		}
-	},
-	"BloodPAC": {
-		"mds_url": "https://data.bloodpac.org",
-		"commons_url": "data.bloodpac.org",
-		"columns_to_fields": {
-			"title": "full_name",
-			"_subjects_count" : "_subjects_count",
-			"_publication_id" : "study_id",
-			"abstract" : "study_description"
-		}
-	},
-	"Genomic Data Commons": {
-		"mds_url": "https://gen3.datacommons.io",
-		"commons_url": "portal.gdc.cancer.gov",
-		"columns_to_fields": {
-			"short_name": "name",
-			"full_name": "full_name",
-			"_subjects_count" : "_subjects_count",
-			"dbgap_accession_number" : "study_id",
-			"_unique_id" : "_unique_id",
-			"description" : "study_description"
+	"gen3_commons": {
+		"IBD Commons": {
+			"mds_url": "https://ibdgc.datacommons.io",
+			"commons_url" : "ibdgc.datacommons.io",
+			"study_data_field" : "my_metadata",
+			"guid_type" : "my_metadata",
+			"columns_to_fields": {
+				"_subjects_count" : "subjects_count",
+				"study_description" : "brief_summary",
+				"short_name": "dataset_title",
+				"full_name": "dataset_title"
+			}
 		},
-		"select_field": {
-			"field_name" : "commons" ,
-			"field_value" : "Genomic Data Commons"
-		}
-	},
-	"Proteomic Data Commons": {
-		"mds_url": "https://gen3.datacommons.io",
-		"commons_url": "portal.gdc.cancer.gov",
-		"columns_to_fields": {
-			"short_name": "name",
-			"full_name": "full_name",
-			"_subjects_count" : "_subjects_count",
-			"dbgap_accession_number" : "study_id",
-			"_unique_id" : "_unique_id",
-			"description" : "study_description"
+		"BioData Catalyst": {
+			"mds_url": "https://gen3.biodatacatalyst.nhlbi.nih.gov",
+			"commons_url" : "gen3.biodatacatalyst.nhlbi.nih.gov",
+			"columns_to_fields": {
+				"short_name": "name",
+				"_unique_id" : "study_id"
+			}
 		},
-		"select_field": {
-			"field_name" : "commons" ,
-			"field_value" : "Proteomic Data Commons"
+		"MIDRC": {
+			"mds_url": "https://data.midrc.org",
+			"commons_url" : "data.midrc.org",
+			"study_data_field" : "discovery_metadata",
+			"columns_to_fields": {
+				"_subjects_count" : "cases_count",
+				"study_description" : "research_description",
+				"_unique_id": "study_id"
+			}
+		},
+		"NIAID ClinicalData": {
+			"mds_url": "https://accessclinicaldata.niaid.nih.gov",
+			"commons_url" : "accessclinicaldata.niaid.nih.gov",
+			"study_data_field" : "my_metadata",
+			"guid_type" : "my_metadata",
+			"columns_to_fields": {
+				"full_name": "title",
+				"study_id" : "nct_number",
+				"_unique_id": "nct_number",
+				"study_description" : "brief_summary"
+			}
+		},
+		"AnVIL": {
+			"mds_url": "https://internalstaging.theanvil.io",
+			"commons_url": "gen3.theanvil.io",
+			"columns_to_fields": {
+				"name": "name",
+				"full_name": "full_name",
+				"_subjects_count" : "_subjects_count",
+				"_unique_id" : "study_id",
+				"study_description" : "study_description"
+			}
 		}
 	}
 }

--- a/tests/test_agg_mds_adapters.py
+++ b/tests/test_agg_mds_adapters.py
@@ -54,8 +54,11 @@ def test_addGen3ExpectedFields():
     study_field = ""
     mappings = {}
     keepOriginalFields = False
+    globalFieldFilters = {}
 
-    item = Gen3Adapter.addGen3ExpectedFields(study_field, mappings, keepOriginalFields)
+    item = Gen3Adapter.addGen3ExpectedFields(
+        study_field, mappings, keepOriginalFields, globalFieldFilters
+    )
 
     assert item == {}
 

--- a/tests/test_populate.py
+++ b/tests/test_populate.py
@@ -47,7 +47,14 @@ async def test_populate_metadata():
                 commons_url="http://commons",
                 columns_to_fields={"column1": "field1"},
             ),
-            {"id1": {"gen3_discovery": {"column1": "some data", "tags": {}}}},
+            {
+                "id1": {
+                    "gen3_discovery": {
+                        "column1": "some data",
+                        "tags": [{"category": "my_category", "name": "my_name"}],
+                    }
+                }
+            },
         )
 
         mock_update.assert_called_with(
@@ -57,14 +64,19 @@ async def test_populate_metadata():
                     "id1": {
                         "gen3_discovery": {
                             "column1": "some data",
-                            "tags": {},
+                            "tags": [
+                                {
+                                    "category": "my_category",
+                                    "name": "my_name",
+                                },
+                            ],
                             "commons_name": "my_commons",
                         }
                     }
                 }
             ],
             ["id1"],
-            {},
+            {"my_category": ["my_name"]},
             {"commons_url": "http://commons"},
             "gen3_discovery",
         )
@@ -131,6 +143,9 @@ async def test_filter_entries():
         [
             {
                 "short_name": {"gen3_discovery": {"my_field": 71}},
+            },
+            {
+                "short_name": {"different_field": {"my_field": 0}},
             },
             {
                 "short_name": {"gen3_discovery": {"my_field": 0}},


### PR DESCRIPTION
Related to https://github.com/uc-cdis/cdis-manifest/pull/3332

Jira Ticket: [HP-291](https://ctds-planx.atlassian.net/browse/HP-291), [HP-320](https://ctds-planx.atlassian.net/browse/HP-320)

### Improvements

* Remove aggregate MDS configs from source control

### Deployment changes

* Per https://github.com/uc-cdis/cdis-manifest/pull/3332 a `metadata/aggregate_config.json` file should be created as part of the manifest config for a commons and the appropriate environment vars for `metadata` should be defined in the manifest JSON
* The new command to populate an aggregate MDS is `kubectl exec $(gen3 pod metadata) -- python /src/src/mds/populate.py --config /aggregate_config.json --hostname esproxy-service --port 9200`
