### PR TITLE
(PXP-9705): update POST /objects endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -411,14 +411,14 @@ paths:
       summary: Create Metadata Indexes
       tags:
       - Index
-  /objects:
+  /objects/upload:
     post:
       description: "Create object placeholder and attach metadata, return Upload url\
         \ to the user.\n\nArgs:\n    body (CreateObjInput): input body for create\
         \ object\n    request (Request): starlette request (which contains reference\
         \ to FastAPI app)\n    token (HTTPAuthorizationCredentials, optional): bearer\
         \ token"
-      operationId: create_object_objects_post
+      operationId: create_object_objects_upload_post
       requestBody:
         content:
           application/json:

--- a/src/mds/objects.py
+++ b/src/mds/objects.py
@@ -72,7 +72,7 @@ class CreateObjForIdInput(BaseModel):
     metadata: dict = None
 
 
-@mod.post("/objects")
+@mod.post("/objects/upload")
 async def create_object(
     body: CreateObjInput,
     request: Request,
@@ -112,6 +112,13 @@ async def create_object(
             HTTP_400_BAD_REQUEST,
             f"Invalid authz.resource_paths, must be valid list of resources, got: {authz.get('resource_paths')}",
         )
+
+    logger.debug(f"checking for allowable aliases")
+    for alias in aliases:
+        if not _is_allowable_guid_or_alias(alias):
+            raise HTTPException(
+                HTTP_400_BAD_REQUEST, f"alias has an unallowed value: {alias}"
+            )
 
     metadata = metadata or {}
 
@@ -658,6 +665,12 @@ async def _add_metadata(blank_guid: str, metadata: dict, authz: dict, uploader: 
 
 def _is_authz_version_supported(authz):
     return str(authz.get("version", "")) == "0"
+
+
+def _is_allowable_guid_or_alias(guid: str):
+    """ guid should not be 'upload' """
+    allowed = guid != "upload"
+    return allowed
 
 
 def init_app(app):


### PR DESCRIPTION
Jira Ticket: [PXP-9705](https://ctds-planx.atlassian.net/browse/PXP-9705)

### New Features


### Breaking Changes


### Bug Fixes


### Improvements

* Rename POST /objects to POST /objects/upload.
* Don't allow "upload" as a GUID or alias

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
