### PR TITLE
Query filter wildcards

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -113,7 +113,10 @@ paths:
         : 4}}}\n    {\"a\": {\"b\": {\"c\": \"3\", \"d\": 4, \"e\": 5}}}\n\nBut won't\
         \ match these:\n\n    {\"a\": {\"b\": {\"c\": 3}}}\n    {\"a\": {\"b\": {\"\
         c\": 3, \"d\": 5}}}\n    {\"a\": {\"b\": {\"d\": 5}}}\n    {\"a\": {\"b\"\
-        : {\"c\": \"333\", \"d\": 4}}}"
+        : {\"c\": \"333\", \"d\": 4}}}\n\nTo query all rows with a given key, regardless\
+        \ of value, use the \"*\" wildcard. For example:\n\n    GET /metadata?a=*\
+        \ or GET /metadata?a.b=*\n\nTo query rows with a value of \"*\" exactly, escape\
+        \ it. For example: \"?a=\\*\"."
       operationId: search_metadata_metadata_get
       parameters:
       - description: Switch to returning a list of GUIDs (false), or GUIDs mapping

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -115,8 +115,10 @@ paths:
         c\": 3, \"d\": 5}}}\n    {\"a\": {\"b\": {\"d\": 5}}}\n    {\"a\": {\"b\"\
         : {\"c\": \"333\", \"d\": 4}}}\n\nTo query all rows with a given key, regardless\
         \ of value, use the \"*\" wildcard. For example:\n\n    GET /metadata?a=*\
-        \ or GET /metadata?a.b=*\n\nTo query rows with a value of \"*\" exactly, escape\
-        \ it. For example: \"?a=\\*\"."
+        \ or GET /metadata?a.b=*\n\nNote that only a single asterisk is supported,\
+        \ not true wildcarding. For\nexample: `?a=1.*` will only match the exact string\
+        \ `\"1.*\"`.\n\nTo query rows with a value of `\"*\"` exactly, escape the\
+        \ asterisk. For example: `?a=\\*`."
       operationId: search_metadata_metadata_get
       parameters:
       - description: Switch to returning a list of GUIDs (false), or GUIDs mapping

--- a/src/mds/agg_mds/datastore/elasticsearch_dao.py
+++ b/src/mds/agg_mds/datastore/elasticsearch_dao.py
@@ -94,7 +94,7 @@ def normalize_field(doc, key, normalize_type):
             doc[key] = None if value is "" else json.loads(value)
         if normalize_type == "number" and isinstance(doc[key], str):
             doc[key] = None
-    except:
+    except Exception:
         logger.debug(f"error normalizing {key} for a document")
         doc[key] = None
 

--- a/src/mds/query.py
+++ b/src/mds/query.py
@@ -72,6 +72,10 @@ async def search_metadata(
     def add_filter(query):
         for path, values in queries.items():
             if "*" in values:
+                # Query all records with a value for this path (value != "").
+                # Because we are filtering JSON, we need to use `astext`
+                # => empty strings and missing values both get cast to "".
+                # The 2nd `where` explicitly adds values matching "".
                 query = query.where(
                     db.or_(
                         Metadata.data[list(path.split("."))].astext != "",

--- a/src/mds/query.py
+++ b/src/mds/query.py
@@ -72,16 +72,10 @@ async def search_metadata(
     def add_filter(query):
         for path, values in queries.items():
             if "*" in values:
-                # Query all records with a value for this path (value != "").
-                # Because we are filtering JSON, we need to use `astext`
-                # => empty strings and missing values both get cast to "".
-                # The 2nd `where` explicitly adds values matching "".
-                query = query.where(
-                    db.or_(
-                        Metadata.data[list(path.split("."))].astext != "",
-                        Metadata.data[list(path.split("."))].astext == "",
-                    )
-                )
+                # query all records with a value for this path
+                path = list(path.split("."))
+                field = path.pop()
+                query = query.where(Metadata.data[path].has_key(field))
             else:
                 values = [v.replace("\*", "*") for v in values]
                 query = query.where(

--- a/src/mds/query.py
+++ b/src/mds/query.py
@@ -77,7 +77,7 @@ async def search_metadata(
                 field = path.pop()
                 query = query.where(Metadata.data[path].has_key(field))
             else:
-                values = [v.replace("\*", "*") for v in values]
+                values = ["*" if v == "\*" else v for v in values]
                 query = query.where(
                     db.or_(
                         Metadata.data[list(path.split("."))].astext == v for v in values

--- a/src/mds/query.py
+++ b/src/mds/query.py
@@ -61,7 +61,10 @@ async def search_metadata(
 
         GET /metadata?a=* or GET /metadata?a.b=*
 
-    To query rows with a value of "*" exactly, escape it. For example: "?a=\*".
+    Note that only a single asterisk is supported, not true wildcarding. For
+    example: `?a=1.*` will only match the exact string `"1.*"`.
+
+    To query rows with a value of `"*"` exactly, escape the asterisk. For example: `?a=\*`.
     """
     limit = min(limit, 2000)
     queries = {}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,7 +30,7 @@ def test_status_aggregate_error(client):
     try:
         resp = client.get("/_status")
         resp.raise_for_status()
-    except:
+    except Exception:
         assert resp.status_code == 500
         assert resp.json() == {
             "detail": {"message": "aggregate datastore offline", "code": 500}

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -52,6 +52,9 @@ def test_query_offset(client):
             client.delete(f"/metadata/tqo_{i}")
 
 
+@pytest.mark.skipif(
+    gino.__version__ <= "0.8.5", reason="https://github.com/fantix/gino/pull/609"
+)
 def test_query_filter(client):
     try:
         for guid, data in [

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -104,6 +104,8 @@ def test_query_filter_all_values(client):
             ("tq_7", dict(b=3)),
         ]:
             client.post(f"/metadata/{guid}", json=data).raise_for_status()
+
+        # query all records with a value for field "a"
         assert list(sorted(client.get("/metadata?a=*").json())) == [
             "tq_1",
             "tq_2",
@@ -111,7 +113,11 @@ def test_query_filter_all_values(client):
             "tq_4",
             "tq_5",
         ]
+
+        # query all records with a value for field "a.b"
         assert list(sorted(client.get("/metadata?a.b=*").json())) == ["tq_5"]
+
+        # query all records with a == "*"
         assert list(sorted(client.get("/metadata?a=\*").json())) == ["tq_4"]
     finally:
         for i in range(1, 8):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -34,7 +34,7 @@ def test_lost_client(client):
 def test_status(client):
     try:
         client.get("/_status").raise_for_status()
-    except:
+    except Exception:
         pass
 
 


### PR DESCRIPTION
We need to query records with `date_to_delete < now` and the MDS doesn’t currently support comparisons in filters, or querying all records that have a `date_to_delete` field so we can compare on the client side. This adds a way to do the latter.

I considered allowing `?a` instead of `?a=*` but then there would be no way to query for the empty string `""`

### New Features
- Wildcards can be used in filters to query all data with a value for a specific field, regardless of value
