### PR TITLE
Fix/remove deprecated metadata keys

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2022-09-28T21:26:32Z",
+  "generated_at": "2022-09-29T17:06:11Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -124,7 +124,7 @@
       {
         "hashed_secret": "ecdb6b62dc6de954dbbef8185029415aecae5e5a",
         "is_verified": false,
-        "line_number": 298,
+        "line_number": 285,
         "type": "Hex High Entropy String"
       }
     ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2022-09-29T17:06:11Z",
+  "generated_at": "2022-10-03T18:10:28Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -124,7 +124,7 @@
       {
         "hashed_secret": "ecdb6b62dc6de954dbbef8185029415aecae5e5a",
         "is_verified": false,
-        "line_number": 285,
+        "line_number": 283,
         "type": "Hex High Entropy String"
       }
     ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": "^.secrets.baseline$",
+    "files": null,
     "lines": null
   },
-  "generated_at": "2022-09-15T16:17:07Z",
+  "generated_at": "2022-09-28T21:26:32Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -90,6 +90,14 @@
         "type": "Hex High Entropy String"
       }
     ],
+    "migrations/versions/6819874e85b9_remove_deprecated_metadata.py": [
+      {
+        "hashed_secret": "ecdb6b62dc6de954dbbef8185029415aecae5e5a",
+        "is_verified": false,
+        "line_number": 15,
+        "type": "Hex High Entropy String"
+      }
+    ],
     "poetry.lock": [
       {
         "hashed_secret": "940ab7206e90c8d2983ca7a38eca2d4a59d85fb5",
@@ -102,7 +110,7 @@
       {
         "hashed_secret": "143e9f2aca10dbd2711cb96047f4016f095e5709",
         "is_verified": false,
-        "line_number": 3638,
+        "line_number": 3898,
         "type": "Hex High Entropy String"
       }
     ],
@@ -111,6 +119,12 @@
         "hashed_secret": "4dcba4ad1d671981e2d211ebe56da8a5b40f14ef",
         "is_verified": false,
         "line_number": 225,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ecdb6b62dc6de954dbbef8185029415aecae5e5a",
+        "is_verified": false,
+        "line_number": 298,
         "type": "Hex High Entropy String"
       }
     ]

--- a/migrations/versions/6819874e85b9_remove_deprecated_metadata.py
+++ b/migrations/versions/6819874e85b9_remove_deprecated_metadata.py
@@ -1,0 +1,60 @@
+"""remove deprecated metadata
+
+Revision ID: 6819874e85b9
+Revises: 3354f2c466ec
+Create Date: 2022-09-27 13:43:39.827523
+
+"""
+import json
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "6819874e85b9"
+down_revision = "3354f2c466ec"
+branch_labels = None
+depends_on = None
+
+
+def escape(str):
+    # escape single quotes for SQL statement
+    return str.replace("'", "''")
+
+
+def upgrade():
+    """Remove deprecated metadata keys."""
+
+    remove_metadata_keys = ["_uploader_id", "_filename", "_bucket", "_file_extension"]
+
+    # extract existing PK (guid) and authz data (resource_path) from the metadata column
+    connection = op.get_bind()
+    offset = 0
+    limit = 500
+    query = (
+        f"SELECT guid, data FROM metadata ORDER BY guid LIMIT {limit} OFFSET {offset}"
+    )
+    results = connection.execute(query).fetchall()
+    while results:
+        for r in results:
+            guid, data = r[0], r[1]
+            have_key = False
+            # scrub internal fields from metadata
+            for metadata_key in remove_metadata_keys:
+                if metadata_key in data.keys():
+                    data.pop(metadata_key)
+                    have_key = True
+            if have_key:
+                sql_statement = f"""UPDATE metadata
+                                    SET data='{escape(json.dumps(data))}'
+                                    WHERE guid='{guid}'"""
+                connection.execute(sql_statement)
+        # Grab another batch of rows
+        offset += limit
+        query = f"SELECT guid, data FROM metadata ORDER BY guid LIMIT {limit} OFFSET {offset} "
+        results = connection.execute(query).fetchall()
+
+
+def downgrade():
+    pass

--- a/migrations/versions/6819874e85b9_remove_deprecated_metadata.py
+++ b/migrations/versions/6819874e85b9_remove_deprecated_metadata.py
@@ -28,7 +28,7 @@ def upgrade():
 
     remove_metadata_keys = ["_uploader_id", "_filename", "_bucket", "_file_extension"]
 
-    # extract existing PK (guid) and authz data (resource_path) from the metadata column
+    # extract existing PK (guid) and metadata (data) columns
     connection = op.get_bind()
     offset = 0
     limit = 500
@@ -39,17 +39,14 @@ def upgrade():
     while results:
         for r in results:
             guid, data = r[0], r[1]
-            have_key = False
             # scrub internal fields from metadata
             for metadata_key in remove_metadata_keys:
                 if metadata_key in data.keys():
                     data.pop(metadata_key)
-                    have_key = True
-            if have_key:
-                sql_statement = f"""UPDATE metadata
-                                    SET data='{escape(json.dumps(data))}'
-                                    WHERE guid='{guid}'"""
-                connection.execute(sql_statement)
+            sql_statement = f"""UPDATE metadata
+                                SET data='{escape(json.dumps(data))}'
+                                WHERE guid='{guid}'"""
+            connection.execute(sql_statement)
         # Grab another batch of rows
         offset += limit
         query = f"SELECT guid, data FROM metadata ORDER BY guid LIMIT {limit} OFFSET {offset} "

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -241,10 +241,8 @@ async def test_4d93784a25e5_upgrade(
 @pytest.mark.asyncio
 async def test_6819874e85b9_upgrade():
     """
-    We can't create metadata by using the `client` fixture because of two reasons:
-    1) Calling the API when the db is in the downgraded state will give
-       UndefinedColumnErrors (metadata.authz) because the db and the data model are out of sync
-    2) this issue: https://github.com/encode/starlette/issues/440
+    We can't create metadata by using the `client` fixture because of this issue:
+    https://github.com/encode/starlette/issues/440
     so inserting directly into the DB instead.
     """
 


### PR DESCRIPTION
Jira Ticket: [HP-908](https://ctds-planx.atlassian.net/browse/HP-908)

### New Features


### Breaking Changes


### Bug Fixes

* Removes deprecated metadata keys in rows that were missed by migration [4d93784a25e5_add_authz_column.py](https://github.com/uc-cdis/metadata-service/blob/master/migrations/versions/4d93784a25e5_add_authz_column.py).

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
