### PR TITLE
fix(offset): ensure deterministic pagination by query when limit/offs…

### DIFF
--- a/src/mds/config.py
+++ b/src/mds/config.py
@@ -70,6 +70,11 @@ DEFAULT_AUTHZ_STR = config(
     default='{"version": 0, "_resource_paths": ["/open"]}',
 )
 
+# Limits
+METADATA_QUERY_RESULTS_LIMIT = config(
+    "METADATA_QUERY_RESULTS_LIMIT", cast=int, default=2000
+)
+
 # Security
 
 ADMIN_LOGINS = config("ADMIN_LOGINS", cast=CommaSeparatedLogins, default=[])


### PR DESCRIPTION
…et-ing (add ORDER BY)


### New Features


### Breaking Changes


### Bug Fixes
- Ensure deterministic pagination by query when limit/offset is used (by adding an explicit ORDER BY)

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
