### PR TITLE
adding in a high "nested_object" limit

### DIFF
--- a/src/mds/agg_mds/datastore/elasticsearch_dao.py
+++ b/src/mds/agg_mds/datastore/elasticsearch_dao.py
@@ -38,7 +38,7 @@ CONFIG = {
             "number_of_replicas": 0,
             "mapping": {
                 "nested_objects": {
-                    "limit": "200000"
+                    "limit": 200000
                 }
             }
         }

--- a/src/mds/agg_mds/datastore/elasticsearch_dao.py
+++ b/src/mds/agg_mds/datastore/elasticsearch_dao.py
@@ -38,7 +38,7 @@ CONFIG = {
             "number_of_replicas": 0,
             "mapping": {
                 "nested_objects": {
-                    "limit": 200000
+                    "limit": 30000000
                 }
             }
         }

--- a/src/mds/agg_mds/datastore/elasticsearch_dao.py
+++ b/src/mds/agg_mds/datastore/elasticsearch_dao.py
@@ -228,6 +228,7 @@ async def update_metadata(
         try:
             elastic_search_client.index(index=index_to_update, id=key, body=doc)
         except Exception as ex:
+            print(f"Failed to index document in index: {index_to_update}")
             raise (ex)
 
 

--- a/src/mds/agg_mds/datastore/elasticsearch_dao.py
+++ b/src/mds/agg_mds/datastore/elasticsearch_dao.py
@@ -32,7 +32,7 @@ INFO_MAPPING = {
 }
 
 CONFIG = {
-    "settings": {"index": {"number_of_shards": 1, "number_of_replicas": 0}},
+    "settings": {"index": {"number_of_shards": 1, "number_of_replicas": 0, "mapping.nested_objects.limit": 200000}},
     "mappings": {"properties": {"array": {"type": "keyword"}}},
 }
 
@@ -40,9 +40,6 @@ SEARCH_CONFIG = {
     "settings": {
         "index": {
             "mapping.ignore_malformed": True,
-            "mapping.nested_objects": {
-                "limit": 20000000,
-            },
             "number_of_shards": 1,
             "number_of_replicas": 0,
             "analysis": {

--- a/src/mds/agg_mds/datastore/elasticsearch_dao.py
+++ b/src/mds/agg_mds/datastore/elasticsearch_dao.py
@@ -38,7 +38,7 @@ CONFIG = {
             "number_of_replicas": 0,
             "mapping": {
                 "nested_objects": {
-                    "limit": 30000000
+                    "limit": 200000
                 }
             }
         }
@@ -50,6 +50,9 @@ SEARCH_CONFIG = {
     "settings": {
         "index": {
             "mapping.ignore_malformed": True,
+            "mapping.nested_objects": {
+                "limit": 200000,
+            },
             "number_of_shards": 1,
             "number_of_replicas": 0,
             "analysis": {

--- a/src/mds/agg_mds/datastore/elasticsearch_dao.py
+++ b/src/mds/agg_mds/datastore/elasticsearch_dao.py
@@ -40,6 +40,9 @@ SEARCH_CONFIG = {
     "settings": {
         "index": {
             "mapping.ignore_malformed": True,
+            "mapping.nested_objects": {
+                "limit": 20000000,
+            },
             "number_of_shards": 1,
             "number_of_replicas": 0,
             "analysis": {

--- a/src/mds/agg_mds/datastore/elasticsearch_dao.py
+++ b/src/mds/agg_mds/datastore/elasticsearch_dao.py
@@ -32,7 +32,17 @@ INFO_MAPPING = {
 }
 
 CONFIG = {
-    "settings": {"index": {"number_of_shards": 1, "number_of_replicas": 0, "mapping.nested_objects.limit": 200000}},
+    "settings": {
+        "index": {
+            "number_of_shards": 1,
+            "number_of_replicas": 0,
+            "mapping": {
+                "nested_objects": {
+                    "limit": "200000"
+                }
+            }
+        }
+    },
     "mappings": {"properties": {"array": {"type": "keyword"}}},
 }
 


### PR DESCRIPTION
### Bug Fixes
A limit to the amount of nested objects was created in ES7. https://github.com/elastic/elasticsearch/issues/26962
In order to resolve this error from occurring when running the aggMDS job- we must increase this limit.


