### PR TITLE
fix(migrations): escape '%' in Alembic DB URL for encoded passwords

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -22,13 +22,12 @@ fileConfig(config.config_file_name)
 # target_metadata = None
 from mds.main import load_modules
 from mds.models import Base
-from mds.config import DB_DSN, DB_CONNECT_RETRIES
+from mds.config import DB_DSN, DB_CONNECT_RETRIES, render_alembic_dsn
 
 load_modules()
-config.set_main_option(
-    "sqlalchemy.url",
-    DB_DSN.set(drivername="postgresql").render_as_string(hide_password=False),
-)
+# render_alembic_dsn() escapes '%' so passwords with URL-encoded reserved
+# characters (e.g. '&' -> '%26') don't break ConfigParser interpolation.
+config.set_main_option("sqlalchemy.url", render_alembic_dsn(DB_DSN))
 target_metadata = Base.metadata
 
 # other values from the config, defined by the needs of env.py,

--- a/src/mds/config.py
+++ b/src/mds/config.py
@@ -60,6 +60,27 @@ DB_SSL = config("DB_SSL", default=None)
 DB_CONNECT_RETRIES = config("DB_CONNECT_RETRIES", cast=int, default=32)
 
 
+def render_alembic_dsn(dsn: URL = DB_DSN) -> str:
+    """Render a database URL string safe for Alembic's config.
+
+    Alembic keeps ``sqlalchemy.url`` in a ``configparser.ConfigParser``, which
+    uses ``%`` to start an interpolation token. When the DB password contains
+    reserved characters, SQLAlchemy percent-encodes them while rendering the URL
+    (e.g. ``&`` -> ``%26``, ``*`` -> ``%2A``). Passing that raw string to
+    ``config.set_main_option("sqlalchemy.url", ...)`` makes ConfigParser fail
+    with ``ValueError: invalid interpolation syntax``.
+
+    Doubling every ``%`` to ``%%`` escapes it for ConfigParser, which restores
+    the original single ``%`` when the value is read back, yielding the correct
+    connection URL.
+    """
+    return (
+        dsn.set(drivername="postgresql")
+        .render_as_string(hide_password=False)
+        .replace("%", "%%")
+    )
+
+
 # Elasticsearch
 ES_RETRY_INTERVAL = config("ES_RETRY_INTERVAL", cast=int, default=20)
 ES_RETRY_LIMIT = config("ES_RETRY_LIMIT", cast=int, default=5)

--- a/tests/test_migrations_url.py
+++ b/tests/test_migrations_url.py
@@ -1,0 +1,79 @@
+"""Tests for the Alembic database URL rendering used by ``migrations/env.py``.
+
+A DB password containing reserved characters (e.g. ``&``, ``*``) gets
+percent-encoded by SQLAlchemy when the connection URL is rendered
+(``&`` -> ``%26``). Alembic stores ``sqlalchemy.url`` in a
+``configparser.ConfigParser``, where ``%`` starts an interpolation token, so the
+un-escaped value used to raise ``ValueError: invalid interpolation syntax``.
+``render_alembic_dsn`` escapes ``%`` -> ``%%`` to prevent that.
+"""
+
+import configparser
+
+from sqlalchemy.engine.url import URL, make_url
+
+from mds.config import render_alembic_dsn
+
+# Password with characters SQLAlchemy percent-encodes: @ & * and a literal %.
+SPECIAL_PASSWORD = "p@ss&word*30%value"
+
+
+def _make_dsn(password=SPECIAL_PASSWORD):
+    return URL.create(
+        drivername="postgresql+asyncpg",
+        username="metadata_user",
+        password=password,
+        host="db",
+        port=5432,
+        database="metadata",
+    )
+
+
+def _configparser_roundtrip(rendered):
+    """Mimic how Alembic stores/reads sqlalchemy.url via ConfigParser."""
+    parser = configparser.ConfigParser()
+    parser.add_section("alembic")
+    parser.set("alembic", "sqlalchemy.url", rendered)
+    return parser.get("alembic", "sqlalchemy.url")
+
+
+def test_render_alembic_dsn_is_configparser_safe():
+    """Rendering must survive ConfigParser and round-trip to the real URL."""
+    rendered = render_alembic_dsn(_make_dsn())
+
+    # Before the fix this line raised ValueError: invalid interpolation syntax.
+    stored = _configparser_roundtrip(rendered)
+
+    url = make_url(stored)
+    assert url.password == SPECIAL_PASSWORD
+    assert url.drivername == "postgresql"
+    assert url.username == "metadata_user"
+    assert url.host == "db"
+    assert url.port == 5432
+    assert url.database == "metadata"
+
+
+def test_render_alembic_dsn_escapes_every_percent():
+    """All percent signs must be doubled so ConfigParser treats them literally."""
+    rendered = render_alembic_dsn(_make_dsn())
+
+    assert "%%26" in rendered  # &
+    assert "%%2A" in rendered  # *
+    assert "%%40" in rendered  # @
+    assert "%%25" in rendered  # literal %
+    # No lone/odd percent may remain after collapsing the escaped pairs.
+    assert "%" not in rendered.replace("%%", "")
+
+
+def test_render_alembic_dsn_plain_password_has_no_escaping():
+    """A password without reserved characters renders without any '%'."""
+    rendered = render_alembic_dsn(_make_dsn(password="simplepass123"))
+
+    assert "%" not in rendered
+    assert make_url(rendered).password == "simplepass123"
+
+
+def test_render_alembic_dsn_forces_postgresql_driver():
+    """The async driver is normalized to plain postgresql for Alembic."""
+    rendered = render_alembic_dsn(_make_dsn())
+    assert rendered.startswith("postgresql://")


### PR DESCRIPTION
Alembic stores sqlalchemy.url in a ConfigParser, which treats '%' as the start of an interpolation token. SQLAlchemy percent-encodes reserved characters in the DB password when rendering the URL (e.g. '&' -> '%26', '*' -> '%2A'), so passing the raw string to set_main_option raised "ValueError: invalid interpolation syntax" and broke db migrations for deployments whose password contains such characters.

Add render_alembic_dsn(), which doubles '%' -> '%%' so ConfigParser treats them literally and restores the correct URL on read. Add unit tests covering the round-trip, escaping, and plain-password cases.

<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

### New Features

### Breaking Changes

### Bug Fixes
migrations: escape '%' in Alembic DB URL for encoded passwords

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
